### PR TITLE
Add skeleton language server

### DIFF
--- a/cmd/regopls.go
+++ b/cmd/regopls.go
@@ -3,21 +3,22 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/open-policy-agent/opa/misc/regopls"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 type regoplsCommandParams struct {
-	testParam	bool
+	testParam bool
 }
 
 var regoplsParams = regoplsCommandParams{}
 
 var regoplsCommand = &cobra.Command{
-	Use:	"regopls [port]",
-	Short: 	"Start Rego language server",
-	Long:	`Start Rego language server.
+	Use:   "regopls [port]",
+	Short: "Start Rego language server",
+	Long: `Start Rego language server.
 WIP.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		_, err := startLanguageServer(args)
@@ -34,7 +35,7 @@ func startLanguageServer(args []string) (int, error) {
 	if len(args) != 1 {
 		return 0, errors.New("incorrect number of args")
 	}
-	regopls.Regopls()
+	regopls.StartLanguageServer()
 	return 0, nil
 }
 

--- a/misc/regopls/cmd.go
+++ b/misc/regopls/cmd.go
@@ -1,5 +1,124 @@
 package regopls
 
-func Regopls() {
-	println("Hello world")
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/open-policy-agent/opa/misc/regopls/logs"
+	"github.com/open-policy-agent/opa/misc/regopls/lsp"
+	"github.com/open-policy-agent/opa/misc/regopls/lsp/defines"
+)
+
+func strPtr(str string) *string {
+	return &str
+}
+
+var logPath *string
+
+func init() {
+	var logger *log.Logger
+	defer func() {
+		logs.Init(logger)
+	}()
+	logPath = flag.String("logs", "", "logs file path")
+	if logPath == nil || *logPath == "" {
+		logger = log.New(os.Stderr, "", 0)
+		return
+	}
+	p := *logPath
+	f, err := os.Open(p)
+	if err == nil {
+		logger = log.New(f, "", 0)
+		return
+	}
+	f, err = os.Create(p)
+	if err == nil {
+		logger = log.New(f, "", 0)
+		return
+	}
+	panic(fmt.Sprintf("logs init error: %v", *logPath))
+}
+
+func StartLanguageServer() {
+	server := lsp.NewServer(&lsp.Options{Network: "tcp", CompletionProvider: &defines.CompletionOptions{
+		TriggerCharacters: &[]string{"."},
+	}})
+	server.OnHover(func(ctx context.Context, req *defines.HoverParams) (result *defines.Hover, err error) {
+		logs.Println("hover: ", req)
+		return &defines.Hover{Contents: defines.MarkupContent{Kind: defines.MarkupKindPlainText, Value: "hello world"}}, nil
+	})
+
+	server.OnCompletion(func(ctx context.Context, req *defines.CompletionParams) (result *[]defines.CompletionItem, err error) {
+		logs.Println("completion: ", req)
+		d := defines.CompletionItemKindText
+		return &[]defines.CompletionItem{defines.CompletionItem{
+			Label:      "code",
+			Kind:       &d,
+			InsertText: strPtr("Hello"),
+		}}, nil
+	})
+
+	server.OnDocumentFormatting(func(ctx context.Context, req *defines.DocumentFormattingParams) (result *[]defines.TextEdit, err error) {
+		logs.Println("format: ", req)
+		line, err := ReadFile(req.TextDocument.Uri)
+		if err != nil {
+			return nil, err
+		}
+		res := []defines.TextEdit{}
+		for i, v := range line {
+			r := convertParagraphs(v)
+			if v != r {
+				res = append(res, defines.TextEdit{
+					Range: defines.Range{
+						Start: defines.Position{uint(i), 0},
+						End:   defines.Position{uint(i), uint(len(v) + 1)},
+					},
+					NewText: r,
+				})
+			}
+		}
+
+		return &res, nil
+	})
+	server.Run()
+}
+
+func ReadFile(filename defines.DocumentUri) ([]string, error) {
+	enEscapeUrl, _ := url.QueryUnescape(string(filename))
+	data, err := ioutil.ReadFile(enEscapeUrl[6:])
+	if err != nil {
+		return nil, err
+	}
+	content := string(data)
+	line := strings.Split(content, "\n")
+	return line, nil
+}
+
+// split paragraphs into sentences, and make the sentence first char uppercase and others lowercase
+func convertParagraphs(paragraph string) string {
+	sentences := []string{}
+	for _, sentence := range strings.Split(paragraph, ".") {
+		sentence = strings.TrimSpace(sentence)
+		s := []string{}
+		w := strings.Split(sentence, " ")
+		for i, v := range w {
+			if len(v) > 0 {
+				if i == 0 {
+					s = append(s, strings.ToUpper(v[0:1])+strings.ToLower(v[1:]))
+				} else {
+					s = append(s, strings.ToLower(v))
+				}
+			}
+		}
+		if len(s) != 0 {
+			sentences = append(sentences, strings.Join(s, " ")+".")
+		}
+	}
+	return strings.Join(sentences, " ")
 }

--- a/misc/regopls/jsonrpc/builtin.go
+++ b/misc/regopls/jsonrpc/builtin.go
@@ -1,0 +1,28 @@
+package jsonrpc
+
+import "context"
+
+// $/cancelRequest
+type cancelParams struct {
+	ID interface{} `json:"id"`
+}
+
+func cancelRequest(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*cancelParams)
+	if params.ID == nil {
+		return nil, nil
+	}
+	session := getSession(ctx)
+	session.cancelJob(params.ID)
+	return nil, nil
+}
+
+func CancelRequest() MethodInfo {
+	return MethodInfo{
+		Name: "$/cancelRequest",
+		NewRequest: func() interface{} {
+			return &cancelParams{}
+		},
+		Handler: cancelRequest,
+	}
+}

--- a/misc/regopls/jsonrpc/conn.go
+++ b/misc/regopls/jsonrpc/conn.go
@@ -1,0 +1,53 @@
+package jsonrpc
+
+import (
+	"fmt"
+	"io"
+)
+
+type ReaderWriter interface {
+	io.Reader
+	io.Writer
+	io.Closer
+}
+type CloserReader interface {
+	io.Reader
+	io.Closer
+}
+
+type CloserWriter interface {
+	io.Writer
+	io.Closer
+}
+
+// The connection of rpc, not limited to net.Conn
+type Conn struct {
+	reader CloserReader
+	writer CloserWriter
+}
+
+func NewConn(reader CloserReader, writer CloserWriter) *Conn {
+	return &Conn{reader: reader, writer: writer}
+}
+
+func (c *Conn) Write(p []byte) (n int, err error) {
+	return c.writer.Write(p)
+}
+func (c *Conn) Read(p []byte) (n int, err error) {
+	return c.reader.Read(p)
+}
+
+func (c *Conn) Close() error {
+	var err1 = c.reader.Close()
+	var err2 = c.reader.Close()
+	if err1 == nil && err2 == nil {
+		return nil
+	}
+	if err1 == nil {
+		return err2
+	}
+	if err2 == nil {
+		return err1
+	}
+	return fmt.Errorf("two errors, err1: %v, err2: %v", err1, err2)
+}

--- a/misc/regopls/jsonrpc/server.go
+++ b/misc/regopls/jsonrpc/server.go
@@ -1,0 +1,55 @@
+package jsonrpc
+
+import (
+	"context"
+	"sync"
+)
+
+type MethodInfo struct {
+	Name       string
+	NewRequest func() interface{}
+	Handler    func(ctx context.Context, req interface{}) (interface{}, error)
+}
+
+type Server struct {
+	session     map[int]*Session
+	nowId       int
+	methods     map[string]MethodInfo
+	sessionLock sync.Mutex
+}
+
+func NewServer() *Server {
+	s := &Server{}
+	s.session = make(map[int]*Session)
+	s.methods = make(map[string]MethodInfo)
+
+	// Register Builtin
+	s.RegisterMethod(CancelRequest())
+
+	return s
+}
+
+func (s *Server) RegisterMethod(m MethodInfo) {
+	s.methods[m.Name] = m
+}
+
+func (s *Server) ConnComeIn(conn ReaderWriter) {
+	session := s.newSession(conn)
+	session.Start()
+}
+
+func (s *Server) removeSession(id int) {
+	s.sessionLock.Lock()
+	defer s.sessionLock.Unlock()
+	delete(s.session, id)
+}
+
+func (s *Server) newSession(conn ReaderWriter) *Session {
+	s.sessionLock.Lock()
+	defer s.sessionLock.Unlock()
+	id := s.nowId
+	s.nowId += 1
+	session := newSession(id, s, conn)
+	s.session[id] = session
+	return session
+}

--- a/misc/regopls/jsonrpc/session.go
+++ b/misc/regopls/jsonrpc/session.go
@@ -1,0 +1,321 @@
+package jsonrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/open-policy-agent/opa/misc/regopls/logs"
+)
+
+type sessionKeyType struct{}
+
+var sessionKey = sessionKeyType{}
+
+type executor struct {
+	id     interface{}
+	cancel context.CancelFunc
+}
+
+type Session struct {
+	id           int
+	server       *Server
+	conn         ReaderWriter
+	executors    map[interface{}]*executor
+	executorLock sync.Mutex
+	writeLock    sync.Mutex
+	cancel       chan struct{}
+}
+
+func newSession(id int, server *Server, conn ReaderWriter) *Session {
+	s := &Session{id: id, server: server, conn: conn}
+	s.executors = make(map[interface{}]*executor)
+	s.cancel = make(chan struct{}, 1)
+	return s
+}
+
+func (s *Session) Start() {
+	for {
+		s.handle()
+		select {
+		case <-s.cancel:
+			return
+		default:
+
+		}
+	}
+}
+
+func (s *Session) handle() {
+	req, err := s.readRequest()
+	if err != nil {
+		err := s.handlerResponse(nil, nil, err)
+		if err != nil {
+			s.handlerError(err)
+		}
+		return
+	}
+	logs.Printf("Request: [%v] [%s], content: [%v]\n", req.ID, req.Method, string(req.Params))
+	err = s.handlerRequest(req)
+	if err != nil {
+		err := s.handlerResponse(req.ID, nil, err)
+		if err != nil {
+			s.handlerError(err)
+		}
+		return
+	}
+}
+
+func (s *Session) registerExecutor(executor *executor) {
+	s.executorLock.Lock()
+	defer s.executorLock.Unlock()
+	s.executors[executor.id] = executor
+}
+
+func (s *Session) removeExecutor(executor *executor) {
+	s.executorLock.Lock()
+	defer s.executorLock.Unlock()
+	delete(s.executors, executor.id)
+}
+
+func (s *Session) readSize(len int) ([]byte, error) {
+	reader := s.conn
+	buf := make([]byte, len)
+	t := 0
+	for t != len {
+		n, err := reader.Read(buf[t:])
+		if err != nil {
+			return buf, err
+		}
+		t += n
+	}
+	return buf, nil
+}
+
+func (s *Session) readRequest() (RequestMessage, error) {
+	lenHeader, err := s.readSize(15)
+	if err != nil {
+		return RequestMessage{}, err
+	}
+	if strings.ToLower(string(lenHeader)) != "content-length:" {
+		return RequestMessage{}, ParseError
+	}
+	var buf []byte
+	state := 0
+	for max := 0; max < 20; max++ {
+		b, err := s.readSize(1)
+		if err != nil {
+			return RequestMessage{}, err
+		}
+		if state == 0 {
+			buf = append(buf, b[0])
+		} else {
+			if b[0] != '\r' && b[0] != '\n' {
+				return RequestMessage{}, ParseError
+			}
+		}
+		if b[0] == '\r' {
+			if state%2 == 0 {
+				state += 1
+			} else {
+				return RequestMessage{}, ParseError
+			}
+		}
+		if b[0] == '\n' {
+			if state%2 == 1 {
+				state += 1
+				if state == 4 {
+					break
+				}
+			} else {
+				return RequestMessage{}, ParseError
+			}
+		}
+	}
+	if state != 4 {
+		return RequestMessage{}, ParseError
+	}
+	contentLen, err := strconv.Atoi(strings.TrimSpace(string(buf)))
+	if err != nil {
+		e := ParseError
+		e.Data = err
+		return RequestMessage{}, e
+	}
+	content, err := s.readSize(contentLen)
+	if err != nil {
+		return RequestMessage{}, err
+	}
+	req := RequestMessage{}
+	err = jsoniter.Unmarshal(content, &req)
+	if err != nil {
+		e := ParseError
+		e.Data = err
+		return RequestMessage{}, e
+	}
+	return req, nil
+}
+
+func getSession(ctx context.Context) *Session {
+	val := ctx.Value(sessionKey)
+	if isNil(val) {
+		return nil
+	}
+	return val.(*Session)
+}
+
+func (s *Session) getExecutor(id interface{}) *executor {
+	if isNil(id) {
+		return nil
+	}
+	s.executorLock.Lock()
+	defer s.executorLock.Unlock()
+	exec, ok := s.executors[id]
+	if !ok {
+		return nil
+	}
+	return exec
+}
+
+func (s *Session) cancelJob(id interface{}) {
+	exec := s.getExecutor(id)
+	if exec == nil {
+		return
+	}
+	exec.cancel()
+	s.removeExecutor(exec)
+}
+
+func (s *Session) execute(mtdInfo MethodInfo, req RequestMessage, args interface{}) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	ctx = context.WithValue(ctx, sessionKey, s)
+	exec := &executor{
+		id:     req.ID,
+		cancel: cancel,
+	}
+	if req.ID != nil {
+		s.registerExecutor(exec)
+	}
+	go func() {
+		defer s.removeExecutor(exec)
+		resp, err := mtdInfo.Handler(ctx, args)
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if isNil(resp) && isNil(err) && isNil(req.ID) {
+			return
+		}
+		err = s.handlerResponse(req.ID, resp, err)
+		if err != nil {
+			s.handlerError(err)
+		}
+	}()
+}
+
+func (s *Session) handlerRequest(req RequestMessage) error {
+	mtd := req.Method
+	mtdInfo, ok := s.server.methods[mtd]
+	if !ok {
+		return MethodNotFound
+	}
+	reqArgs := mtdInfo.NewRequest()
+	err := jsoniter.Unmarshal(req.Params, reqArgs)
+	if err != nil {
+		return ParseError
+	}
+	s.execute(mtdInfo, req, reqArgs)
+	return nil
+}
+
+func (s *Session) write(resp ResponseMessage) error {
+	s.writeLock.Lock()
+	defer s.writeLock.Unlock()
+	res, err := jsoniter.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	logs.Printf("Response: [%v] res: [%v]\n", resp.ID, string(res))
+	totalLen := len(res)
+	err = s.mustWrite([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", totalLen)))
+	if err != nil {
+		return err
+	}
+	err = s.mustWrite(res)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Session) mustWrite(data []byte) error {
+	t := 0
+	for t != len(data) {
+		n, err := s.conn.Write(data[t:])
+		if err != nil {
+			return err
+		}
+		t += n
+	}
+	return nil
+}
+func (s *Session) handlerResponse(id interface{}, result interface{}, err error) error {
+	resp := ResponseMessage{ID: id}
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return err
+		}
+		if e, ok := err.(ResponseError); ok {
+			resp.Error = &e
+		} else {
+			return err
+		}
+	}
+	resp.Result = result
+	return s.write(resp)
+}
+
+func (s *Session) handlerError(err error) {
+	if errors.Is(err, io.EOF) {
+		// conn done, close conn and remove session
+		err := s.conn.Close()
+		if err != nil {
+			logs.Println("close error: ", err)
+		}
+		func() {
+			s.executorLock.Lock()
+			defer s.executorLock.Unlock()
+			for _, v := range s.executors {
+				if v != nil {
+					v.cancel()
+				}
+			}
+		}()
+
+		select {
+		case s.cancel <- struct{}{}:
+		default:
+		}
+		s.server.removeSession(s.id)
+	}
+	logs.Println("error: ", err)
+	return
+}
+
+func isNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	v := reflect.ValueOf(i)
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return true
+	}
+	return false
+}

--- a/misc/regopls/jsonrpc/types.go
+++ b/misc/regopls/jsonrpc/types.go
@@ -1,0 +1,115 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type BaseMessage struct {
+	Jsonrpc string `json:"jsonrpc"`
+}
+
+type RequestMessage struct {
+	BaseMessage
+	ID     interface{}     `json:"id"` // may be int or string
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"` // params, is some struct or slice
+}
+
+type NotificationMessage struct {
+	BaseMessage
+	Method string          `json:"method"` // starts with "/$", server build-in methods.
+	Params json.RawMessage `json:"params"` // params, is some struct or slice
+}
+
+type ResponseMessage struct {
+	BaseMessage
+	ID     interface{}    `json:"id"` // may be int or string
+	Result interface{}    `json:"result"`
+	Error  *ResponseError `json:"error"`
+}
+
+type ResponseError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
+}
+
+type CancelParams struct {
+	ID interface{} `json:"id"` // the method id should be canceled
+}
+
+type ProgressParams struct {
+	Token interface{} `json:"token"` // int or string
+	/**
+	 * The progress data.
+	 */
+	Value interface{} `json:"value"`
+}
+
+func (r ResponseError) Error() string {
+	return fmt.Sprintf("code: %d, message: %s, data: %v", r.Code, r.Message, r.Data)
+}
+
+type BuildInError = ResponseError
+
+const ParseErrorCode = -32700
+const InvalidRequestCode = -32600
+const MethodNotFoundCode = -32601
+const InvalidParamsCode = -32602
+const InternalErrorCode = -32603
+const jsonrpcReservedErrorRangeStartCode = -32099
+const serverErrorStartCode = jsonrpcReservedErrorRangeStartCode
+const ServerNotInitializedCode = -32002
+const UnknownErrorCodeCode = -32001
+const jsonrpcReservedErrorRangeEnCode = -32000
+const serverErrorEndCode = jsonrpcReservedErrorRangeEnCode
+const lspReservedErrorRangeStartCode = -32899
+const ContentModifiedCode = -32801
+const RequestCancelledCode = -32800
+const lspReservedErrorRangeEndCode = -32800
+
+var ParseError = BuildInError{
+	Code:    ParseErrorCode,
+	Message: "ParseError",
+}
+
+var InvalidRequest = BuildInError{
+	Code:    InvalidRequestCode,
+	Message: "InvalidRequest",
+}
+
+var MethodNotFound = BuildInError{
+	Code:    MethodNotFoundCode,
+	Message: "MethodNotFound",
+}
+
+var InvalidParams = BuildInError{
+	Code:    InvalidParamsCode,
+	Message: "InvalidParams",
+}
+
+var InternalError = BuildInError{
+	Code:    InternalErrorCode,
+	Message: "InternalError",
+}
+
+var ServerNotInitialized = BuildInError{
+	Code:    ServerNotInitializedCode,
+	Message: "ServerNotInitialized",
+}
+
+var UnknownErrorCode = BuildInError{
+	Code:    UnknownErrorCodeCode,
+	Message: "UnknownErrorCode",
+}
+
+var ContentModified = BuildInError{
+	Code:    ContentModifiedCode,
+	Message: "ContentModified",
+}
+
+var RequestCancelled = BuildInError{
+	Code:    RequestCancelledCode,
+	Message: "RequestCancelled",
+}

--- a/misc/regopls/logs/log.go
+++ b/misc/regopls/logs/log.go
@@ -1,0 +1,17 @@
+package logs
+
+import "log"
+
+var logger *log.Logger
+
+func Init(l *log.Logger) {
+	logger = l
+}
+
+func Println(v ...interface{}) {
+	logger.Println(v...)
+}
+
+func Printf(fmt string, v ...interface{}) {
+	logger.Printf(fmt, v...)
+}

--- a/misc/regopls/lsp/builtin.go
+++ b/misc/regopls/lsp/builtin.go
@@ -1,0 +1,164 @@
+package lsp
+
+import (
+	"context"
+
+	"github.com/open-policy-agent/opa/misc/regopls/lsp/defines"
+)
+
+func (m *Methods) builtinInitialize(ctx context.Context, req *defines.InitializeParams) (defines.InitializeResult, error) {
+	resp := defines.InitializeResult{}
+	resp.Capabilities.TextDocumentSync = defines.TextDocumentSyncKindFull
+	if m.Opt.CompletionProvider != nil {
+		resp.Capabilities.CompletionProvider = m.Opt.CompletionProvider
+	} else if m.onCompletion != nil {
+		resp.Capabilities.CompletionProvider = &defines.CompletionOptions{
+			TriggerCharacters: &[]string{"."},
+		}
+	}
+	if m.Opt.HoverProvider != nil {
+		resp.Capabilities.HoverProvider = m.Opt.HoverProvider
+	} else if m.onHover != nil {
+		resp.Capabilities.HoverProvider = true
+	}
+	if m.Opt.SignatureHelpProvider != nil {
+		resp.Capabilities.SignatureHelpProvider = m.Opt.SignatureHelpProvider
+	} else if m.onSignatureHelp != nil {
+		resp.Capabilities.SignatureHelpProvider = &defines.SignatureHelpOptions{
+			TriggerCharacters: &[]string{"(", ","},
+		}
+	}
+	if m.Opt.DeclarationProvider != nil {
+		resp.Capabilities.DeclarationProvider = m.Opt.DeclarationProvider
+	} else if m.onDeclaration != nil {
+		resp.Capabilities.DeclarationProvider = true
+	}
+	if m.Opt.DefinitionProvider != nil {
+		resp.Capabilities.DefinitionProvider = m.Opt.DefinitionProvider
+	} else if m.onDefinition != nil {
+		resp.Capabilities.DefinitionProvider = true
+	}
+	if m.Opt.TypeDefinitionProvider != nil {
+		resp.Capabilities.TypeDefinitionProvider = m.Opt.TypeDefinitionProvider
+	} else if m.onTypeDefinition != nil {
+		resp.Capabilities.TypeDefinitionProvider = true
+	}
+	if m.Opt.ImplementationProvider != nil {
+		resp.Capabilities.ImplementationProvider = m.Opt.ImplementationProvider
+	} else if m.onImplementation != nil {
+		resp.Capabilities.ImplementationProvider = true
+	}
+
+	if m.Opt.ReferencesProvider != nil {
+		resp.Capabilities.ReferencesProvider = m.Opt.ReferencesProvider
+	} else if m.onReferences != nil {
+		resp.Capabilities.ReferencesProvider = true
+	}
+
+	if m.Opt.DocumentHighlightProvider != nil {
+		resp.Capabilities.DocumentHighlightProvider = m.Opt.DocumentHighlightProvider
+	} else if m.onDocumentHighlight != nil {
+		resp.Capabilities.DocumentHighlightProvider = true
+	}
+
+	if m.Opt.DocumentSymbolProvider != nil {
+		resp.Capabilities.DocumentSymbolProvider = m.Opt.DocumentSymbolProvider
+	} else if m.onDocumentSymbolWithSliceDocumentSymbol != nil {
+		resp.Capabilities.DocumentSymbolProvider = true
+	} else if m.onDocumentSymbolWithSliceSymbolInformation != nil {
+		resp.Capabilities.DocumentSymbolProvider = true
+	}
+	if m.Opt.CodeActionProvider != nil {
+		resp.Capabilities.CodeActionProvider = m.Opt.CodeActionProvider
+	} else if m.onCodeActionWithSliceCodeAction != nil {
+		resp.Capabilities.CodeActionProvider = true
+	} else if m.onCodeActionWithSliceCommand != nil {
+		resp.Capabilities.CodeActionProvider = true
+	}
+	if m.Opt.CodeLensProvider != nil {
+		resp.Capabilities.CodeLensProvider = m.Opt.CodeLensProvider
+	} else if m.onCodeLens != nil {
+		t := true
+		resp.Capabilities.CodeLensProvider = &defines.CodeLensOptions{WorkDoneProgressOptions: defines.WorkDoneProgressOptions{WorkDoneProgress: &t}, ResolveProvider: &t}
+	}
+	if m.Opt.DocumentLinkProvider != nil {
+		resp.Capabilities.DocumentLinkProvider = m.Opt.DocumentLinkProvider
+	} else if m.onDocumentLinks != nil {
+		t := true
+		resp.Capabilities.DocumentLinkProvider = &defines.DocumentLinkOptions{WorkDoneProgressOptions: defines.WorkDoneProgressOptions{WorkDoneProgress: &t}, ResolveProvider: &t}
+	}
+	if m.Opt.ColorProvider != nil {
+		resp.Capabilities.ColorProvider = m.Opt.ColorProvider
+	} else if m.onDocumentColor != nil {
+		resp.Capabilities.ColorProvider = true
+	}
+	if m.Opt.WorkspaceSymbolProvider != nil {
+		resp.Capabilities.WorkspaceSymbolProvider = m.Opt.WorkspaceSymbolProvider
+	} else if m.onWorkspaceSymbol != nil {
+		resp.Capabilities.WorkspaceSymbolProvider = true
+	}
+	if m.Opt.DocumentFormattingProvider != nil {
+		resp.Capabilities.DocumentFormattingProvider = m.Opt.DocumentFormattingProvider
+	} else if m.onDocumentFormatting != nil {
+		resp.Capabilities.DocumentFormattingProvider = true
+	}
+	if m.Opt.DocumentRangeFormattingProvider != nil {
+		resp.Capabilities.DocumentRangeFormattingProvider = m.Opt.DocumentRangeFormattingProvider
+	} else if m.onDocumentRangeFormatting != nil {
+		resp.Capabilities.DocumentRangeFormattingProvider = true
+	}
+	if m.Opt.DocumentOnTypeFormattingProvider != nil {
+		resp.Capabilities.DocumentOnTypeFormattingProvider = m.Opt.DocumentOnTypeFormattingProvider
+	} else if m.onDocumentOnTypeFormatting != nil {
+		// TODO
+		resp.Capabilities.DocumentOnTypeFormattingProvider = &defines.DocumentOnTypeFormattingOptions{}
+	}
+	if m.Opt.RenameProvider != nil {
+		resp.Capabilities.RenameProvider = m.Opt.RenameProvider
+	} else if m.onPrepareRename != nil {
+		resp.Capabilities.RenameProvider = true
+	}
+	if m.Opt.FoldingRangeProvider != nil {
+		resp.Capabilities.FoldingRangeProvider = m.Opt.FoldingRangeProvider
+	} else if m.onFoldingRanges != nil {
+		resp.Capabilities.FoldingRangeProvider = true
+	}
+	if m.Opt.SelectionRangeProvider != nil {
+		resp.Capabilities.SelectionRangeProvider = m.Opt.SelectionRangeProvider
+	} else if m.onSelectionRanges != nil {
+		resp.Capabilities.SelectionRangeProvider = true
+	}
+	if m.Opt.ExecuteCommandProvider != nil {
+		resp.Capabilities.ExecuteCommandProvider = m.Opt.ExecuteCommandProvider
+	} else if m.onExecuteCommand != nil {
+		// TODO
+		resp.Capabilities.ExecuteCommandProvider = &defines.ExecuteCommandOptions{}
+	}
+	if m.Opt.DocumentLinkProvider != nil {
+		resp.Capabilities.DocumentLinkProvider = m.Opt.DocumentLinkProvider
+	} else if m.onDocumentLinks != nil {
+		// TODO
+		resp.Capabilities.DocumentLinkProvider = &defines.DocumentLinkOptions{}
+	}
+	if m.Opt.SemanticTokensProvider != nil {
+		resp.Capabilities.SemanticTokensProvider = m.Opt.SemanticTokensProvider
+	}
+
+	if m.Opt.MonikerProvider != nil {
+		resp.Capabilities.MonikerProvider = m.Opt.MonikerProvider
+	}
+
+	if m.Opt.CallHierarchyProvider != nil {
+		resp.Capabilities.CallHierarchyProvider = m.Opt.CallHierarchyProvider
+	}
+
+	//}
+	//if m.onMon != nil{
+	//	resp.Capabilities.MonikerProvider = true
+	//}
+	//if m.onTypeHierarchy != nil{
+	//	resp.Capabilities.TypeHierarchyProvider = true
+	//}
+
+	return resp, nil
+}

--- a/misc/regopls/lsp/defines/protocol.callHierarchy.go
+++ b/misc/regopls/lsp/defines/protocol.callHierarchy.go
@@ -1,0 +1,66 @@
+package defines
+
+/**
+ * @since 3.16.0
+ */
+type CallHierarchyClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration. If this is set to `true`
+	// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+	// return value for the corresponding server capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * Call hierarchy options used during static registration.
+ *
+ * @since 3.16.0
+ */
+type CallHierarchyOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Call hierarchy options used during static or dynamic registration.
+ *
+ * @since 3.16.0
+ */
+type CallHierarchyRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	CallHierarchyOptions
+	StaticRegistrationOptions
+}
+
+/**
+ * The parameter of a `textDocument/prepareCallHierarchy` request.
+ *
+ * @since 3.16.0
+ */
+type CallHierarchyPrepareParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+}
+
+/**
+ * The parameter of a `callHierarchy/incomingCalls` request.
+ *
+ * @since 3.16.0
+ */
+type CallHierarchyIncomingCallsParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	Item CallHierarchyItem `json:"item,omitempty"`
+}
+
+/**
+ * The parameter of a `callHierarchy/outgoingCalls` request.
+ *
+ * @since 3.16.0
+ */
+type CallHierarchyOutgoingCallsParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	Item CallHierarchyItem `json:"item,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.colorProvider.go
+++ b/misc/regopls/lsp/defines/protocol.colorProvider.go
@@ -1,0 +1,48 @@
+package defines
+
+// ---- Client capability ----
+type DocumentColorClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration. If this is set to `true`
+	// the client supports the new `DocumentColorRegistrationOptions` return value
+	// for the corresponding server capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+type DocumentColorOptions struct {
+	WorkDoneProgressOptions
+}
+
+type DocumentColorRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	StaticRegistrationOptions
+	DocumentColorOptions
+}
+
+/**
+ * Parameters for a [DocumentColorRequest](#DocumentColorRequest).
+ */
+type DocumentColorParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+}
+
+/**
+ * Parameters for a [ColorPresentationRequest](#ColorPresentationRequest).
+ */
+type ColorPresentationParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The color to request presentations for.
+	Color Color `json:"color,omitempty"`
+
+	// The range where the color would be inserted. Serves as a context.
+	Range Range `json:"range,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.configuration.go
+++ b/misc/regopls/lsp/defines/protocol.configuration.go
@@ -1,0 +1,30 @@
+package defines
+
+// ---- Get Configuration request ----
+type ConfigurationClientCapabilities struct {
+
+	// The workspace client capabilities
+	Workspace *struct {
+
+		// The client supports `workspaceconfiguration` requests.
+		//
+		// @since 3.6.0
+		Configuration *bool `json:"configuration,omitempty"`
+	} `json:"workspace,omitempty"`
+}
+
+type ConfigurationItem struct {
+
+	// The scope to get the configuration section for.
+	ScopeUri *string `json:"scopeUri,omitempty"`
+
+	// The configuration section asked for.
+	Section *string `json:"section,omitempty"`
+}
+
+/**
+ * The parameters of a configuration request.
+ */
+type ConfigurationParams struct {
+	Items []ConfigurationItem `json:"items,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.declaration.go
+++ b/misc/regopls/lsp/defines/protocol.declaration.go
@@ -1,0 +1,31 @@
+package defines
+
+/**
+ * @since 3.14.0
+ */
+type DeclarationClientCapabilities struct {
+
+	// Whether declaration supports dynamic registration. If this is set to `true`
+	// the client supports the new `DeclarationRegistrationOptions` return value
+	// for the corresponding server capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The client supports additional metadata in the form of declaration links.
+	LinkSupport *bool `json:"linkSupport,omitempty"`
+}
+
+type DeclarationOptions struct {
+	WorkDoneProgressOptions
+}
+
+type DeclarationRegistrationOptions struct {
+	DeclarationOptions
+	TextDocumentRegistrationOptions
+	StaticRegistrationOptions
+}
+
+type DeclarationParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+	PartialResultParams
+}

--- a/misc/regopls/lsp/defines/protocol.fileOperations.go
+++ b/misc/regopls/lsp/defines/protocol.fileOperations.go
@@ -1,0 +1,211 @@
+package defines
+
+/**
+ * Options for notifications/requests for user operations on files.
+ *
+ * @since 3.16.0
+ */
+type FileOperationOptions struct {
+
+	// The server is interested in didCreateFiles notifications.
+	DidCreate *FileOperationRegistrationOptions `json:"didCreate,omitempty"`
+
+	// The server is interested in willCreateFiles requests.
+	WillCreate *FileOperationRegistrationOptions `json:"willCreate,omitempty"`
+
+	// The server is interested in didRenameFiles notifications.
+	DidRename *FileOperationRegistrationOptions `json:"didRename,omitempty"`
+
+	// The server is interested in willRenameFiles requests.
+	WillRename *FileOperationRegistrationOptions `json:"willRename,omitempty"`
+
+	// The server is interested in didDeleteFiles file notifications.
+	DidDelete *FileOperationRegistrationOptions `json:"didDelete,omitempty"`
+
+	// The server is interested in willDeleteFiles file requests.
+	WillDelete *FileOperationRegistrationOptions `json:"willDelete,omitempty"`
+}
+
+/**
+ * The options to register for file operations.
+ *
+ * @since 3.16.0
+ */
+type FileOperationRegistrationOptions struct {
+
+	// The actual filters.
+	Filters []FileOperationFilter `json:"filters,omitempty"`
+}
+
+/**
+ * Matching options for the file operation pattern.
+ *
+ * @since 3.16.0
+ */
+type FileOperationPatternOptions struct {
+
+	// The pattern should be matched ignoring casing.
+	IgnoreCase *bool `json:"ignoreCase,omitempty"`
+}
+
+/**
+ * A pattern to describe in which file operation requests or notifications
+ * the server is interested in.
+ *
+ * @since 3.16.0
+ */
+type FileOperationPattern struct {
+
+	// The glob pattern to match. Glob patterns can have the following syntax:
+	// - `` to match one or more characters in a path segment
+	// - `?` to match on one character in a path segment
+	// - `` to match any number of path segments, including none
+	// - `{}` to group sub patterns into an OR expression. (e.g. `​.{ts,js}` matches all TypeScript and JavaScript files)
+	// - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+	// - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+	Glob string `json:"glob,omitempty"`
+
+	// Whether to match files or folders with this pattern.
+	//
+	// Matches both if undefined.
+	Matches *FileOperationPatternKind `json:"matches,omitempty"`
+
+	// Additional options used during matching.
+	Options *FileOperationPatternOptions `json:"options,omitempty"`
+}
+
+/**
+ * A filter to describe in which file operation requests or notifications
+ * the server is interested in.
+ *
+ * @since 3.16.0
+ */
+type FileOperationFilter struct {
+
+	// A Uri like `file` or `untitled`.
+	Scheme *string `json:"scheme,omitempty"`
+
+	// The actual file operation pattern.
+	Pattern FileOperationPattern `json:"pattern,omitempty"`
+}
+
+/**
+ * Capabilities relating to events from file operations by the user in the client.
+ *
+ * These events do not come from the file system, they come from user operations
+ * like renaming a file in the UI.
+ *
+ * @since 3.16.0
+ */
+type FileOperationClientCapabilities struct {
+
+	// Whether the client supports dynamic registration for file requestsnotifications.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The client has support for sending didCreateFiles notifications.
+	DidCreate *bool `json:"didCreate,omitempty"`
+
+	// The client has support for willCreateFiles requests.
+	WillCreate *bool `json:"willCreate,omitempty"`
+
+	// The client has support for sending didRenameFiles notifications.
+	DidRename *bool `json:"didRename,omitempty"`
+
+	// The client has support for willRenameFiles requests.
+	WillRename *bool `json:"willRename,omitempty"`
+
+	// The client has support for sending didDeleteFiles notifications.
+	DidDelete *bool `json:"didDelete,omitempty"`
+
+	// The client has support for willDeleteFiles requests.
+	WillDelete *bool `json:"willDelete,omitempty"`
+}
+
+/**
+ * The parameters sent in file create requests/notifications.
+ *
+ * @since 3.16.0
+ */
+type CreateFilesParams struct {
+
+	// An array of all filesfolders created in this operation.
+	Files []FileCreate `json:"files,omitempty"`
+}
+
+/**
+ * Represents information on a file/folder create.
+ *
+ * @since 3.16.0
+ */
+type FileCreate struct {
+
+	// A file: URI for the location of the filefolder being created.
+	Uri string `json:"uri,omitempty"`
+}
+
+/**
+ * The parameters sent in file rename requests/notifications.
+ *
+ * @since 3.16.0
+ */
+type RenameFilesParams struct {
+
+	// An array of all filesfolders renamed in this operation. When a folder is renamed, only
+	// the folder will be included, and not its children.
+	Files []FileRename `json:"files,omitempty"`
+}
+
+/**
+ * Represents information on a file/folder rename.
+ *
+ * @since 3.16.0
+ */
+type FileRename struct {
+
+	// A file: URI for the original location of the filefolder being renamed.
+	OldUri string `json:"oldUri,omitempty"`
+
+	// A file: URI for the new location of the filefolder being renamed.
+	NewUri string `json:"newUri,omitempty"`
+}
+
+/**
+ * The parameters sent in file delete requests/notifications.
+ *
+ * @since 3.16.0
+ */
+type DeleteFilesParams struct {
+
+	// An array of all filesfolders deleted in this operation.
+	Files []FileDelete `json:"files,omitempty"`
+}
+
+/**
+ * Represents information on a file/folder delete.
+ *
+ * @since 3.16.0
+ */
+type FileDelete struct {
+
+	// A file: URI for the location of the filefolder being deleted.
+	Uri string `json:"uri,omitempty"`
+}
+
+/**
+ * A pattern kind describing if a glob pattern matches a file a folder or
+ * both.
+ *
+ * @since 3.16.0
+ */
+type FileOperationPatternKind string
+
+const (
+	/**
+	 * The pattern matches a file only.
+	 */
+	FileOperationPatternKindFile FileOperationPatternKind = "file"
+	/**
+	 * The pattern matches a folder only.
+	 */
+	FileOperationPatternKindFolder FileOperationPatternKind = "folder"
+)

--- a/misc/regopls/lsp/defines/protocol.foldingRange.go
+++ b/misc/regopls/lsp/defines/protocol.foldingRange.go
@@ -1,0 +1,39 @@
+package defines
+
+// ---- capabilities
+type FoldingRangeClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration for folding range providers. If this is set to `true`
+	// the client supports the new `FoldingRangeRegistrationOptions` return value for the corresponding server
+	// capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The maximum number of folding ranges that the client prefers to receive per document. The value serves as a
+	// hint, servers are free to follow the limit.
+	RangeLimit *uint `json:"rangeLimit,omitempty"`
+
+	// If set, the client signals that it only supports folding complete lines. If set, client will
+	// ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
+	LineFoldingOnly *bool `json:"lineFoldingOnly,omitempty"`
+}
+
+type FoldingRangeOptions struct {
+	WorkDoneProgressOptions
+}
+
+type FoldingRangeRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	FoldingRangeOptions
+	StaticRegistrationOptions
+}
+
+/**
+ * Parameters for a [FoldingRangeRequest](#FoldingRangeRequest).
+ */
+type FoldingRangeParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.go
+++ b/misc/regopls/lsp/defines/protocol.go
@@ -1,0 +1,2732 @@
+package defines
+
+type ClientCapabilities struct {
+	_ClientCapabilities
+	WorkspaceFoldersClientCapabilities
+	ConfigurationClientCapabilities
+	WorkDoneProgressClientCapabilities
+}
+type ServerCapabilities struct {
+	_ServerCapabilities
+	WorkspaceFoldersServerCapabilities
+}
+type InitializeParams struct {
+	_InitializeParams
+	WorkspaceFoldersInitializeParams
+}
+
+type _ServerCapabilities struct {
+
+	// Defines how text documents are synced. Is either a detailed structure defining each notification or
+	// for backwards compatibility the TextDocumentSyncKind number.
+	TextDocumentSync interface{} `json:"textDocumentSync,omitempty"` // TextDocumentSyncOptions, TextDocumentSyncKind,
+
+	// The server provides completion support.
+	CompletionProvider *CompletionOptions `json:"completionProvider,omitempty"`
+
+	// The server provides hover support.
+	HoverProvider interface{} `json:"hoverProvider,omitempty"` // bool, HoverOptions,
+
+	// The server provides signature help support.
+	SignatureHelpProvider *SignatureHelpOptions `json:"signatureHelpProvider,omitempty"`
+
+	// The server provides Goto Declaration support.
+	DeclarationProvider interface{} `json:"declarationProvider,omitempty"` // bool, DeclarationOptions, DeclarationRegistrationOptions,
+
+	// The server provides goto definition support.
+	DefinitionProvider interface{} `json:"definitionProvider,omitempty"` // bool, DefinitionOptions,
+
+	// The server provides Goto Type Definition support.
+	TypeDefinitionProvider interface{} `json:"typeDefinitionProvider,omitempty"` // bool, TypeDefinitionOptions, TypeDefinitionRegistrationOptions,
+
+	// The server provides Goto Implementation support.
+	ImplementationProvider interface{} `json:"implementationProvider,omitempty"` // bool, ImplementationOptions, ImplementationRegistrationOptions,
+
+	// The server provides find references support.
+	ReferencesProvider interface{} `json:"referencesProvider,omitempty"` // bool, ReferenceOptions,
+
+	// The server provides document highlight support.
+	DocumentHighlightProvider interface{} `json:"documentHighlightProvider,omitempty"` // bool, DocumentHighlightOptions,
+
+	// The server provides document symbol support.
+	DocumentSymbolProvider interface{} `json:"documentSymbolProvider,omitempty"` // bool, DocumentSymbolOptions,
+
+	// The server provides code actions. CodeActionOptions may only be
+	// specified if the client states that it supports
+	// `codeActionLiteralSupport` in its initial `initialize` request.
+	CodeActionProvider interface{} `json:"codeActionProvider,omitempty"` // bool, CodeActionOptions,
+
+	// The server provides code lens.
+	CodeLensProvider *CodeLensOptions `json:"codeLensProvider,omitempty"`
+
+	// The server provides document link support.
+	DocumentLinkProvider *DocumentLinkOptions `json:"documentLinkProvider,omitempty"`
+
+	// The server provides color provider support.
+	ColorProvider interface{} `json:"colorProvider,omitempty"` // bool, DocumentColorOptions, DocumentColorRegistrationOptions,
+
+	// The server provides workspace symbol support.
+	WorkspaceSymbolProvider interface{} `json:"workspaceSymbolProvider,omitempty"` // bool, WorkspaceSymbolOptions,
+
+	// The server provides document formatting.
+	DocumentFormattingProvider interface{} `json:"documentFormattingProvider,omitempty"` // bool, DocumentFormattingOptions,
+
+	// The server provides document range formatting.
+	DocumentRangeFormattingProvider interface{} `json:"documentRangeFormattingProvider,omitempty"` // bool, DocumentRangeFormattingOptions,
+
+	// The server provides document formatting on typing.
+	DocumentOnTypeFormattingProvider *DocumentOnTypeFormattingOptions `json:"documentOnTypeFormattingProvider,omitempty"`
+
+	// The server provides rename support. RenameOptions may only be
+	// specified if the client states that it supports
+	// `prepareSupport` in its initial `initialize` request.
+	RenameProvider interface{} `json:"renameProvider,omitempty"` // bool, RenameOptions,
+
+	// The server provides folding provider support.
+	FoldingRangeProvider interface{} `json:"foldingRangeProvider,omitempty"` // bool, FoldingRangeOptions, FoldingRangeRegistrationOptions,
+
+	// The server provides selection range support.
+	SelectionRangeProvider interface{} `json:"selectionRangeProvider,omitempty"` // bool, SelectionRangeOptions, SelectionRangeRegistrationOptions,
+
+	// The server provides execute command support.
+	ExecuteCommandProvider *ExecuteCommandOptions `json:"executeCommandProvider,omitempty"`
+
+	// The server provides call hierarchy support.
+	//
+	// @since 3.16.0
+	CallHierarchyProvider interface{} `json:"callHierarchyProvider,omitempty"` // bool, CallHierarchyOptions, CallHierarchyRegistrationOptions,
+
+	// The server provides linked editing range support.
+	//
+	// @since 3.16.0
+	LinkedEditingRangeProvider interface{} `json:"linkedEditingRangeProvider,omitempty"` // bool, LinkedEditingRangeOptions, LinkedEditingRangeRegistrationOptions,
+
+	// The server provides semantic tokens support.
+	//
+	// @since 3.16.0
+	SemanticTokensProvider interface{} `json:"semanticTokensProvider,omitempty"` // SemanticTokensOptions, SemanticTokensRegistrationOptions,
+
+	// Window specific server capabilities.
+	Workspace *struct {
+
+		// The server is interested in notificationsrequests for operations on files.
+		//
+		// @since 3.16.0
+		FileOperations *FileOperationOptions `json:"fileOperations,omitempty"`
+	} `json:"workspace,omitempty"`
+
+	// The server provides moniker support.
+	//
+	// @since 3.16.0
+	MonikerProvider interface{} `json:"monikerProvider,omitempty"` // bool, MonikerOptions, MonikerRegistrationOptions,
+
+	// Experimental server capabilities.
+	Experimental interface{} `json:"experimental,omitempty"`
+}
+
+/**
+ * @deprecated Use ApplyWorkspaceEditResult instead.
+ */
+type ApplyWorkspaceEditResponse ApplyWorkspaceEditResult
+
+/**
+ * General parameters to to register for an notification or to register a provider.
+ */
+type Registration struct {
+
+	// The id used to register the request. The id can be used to deregister
+	// the request again.
+	Id string `json:"id,omitempty"`
+
+	// The method to register for.
+	Method string `json:"method,omitempty"`
+
+	// Options necessary for the registration.
+	RegisterOptions interface{} `json:"registerOptions,omitempty"`
+}
+
+type RegistrationParams struct {
+	Registrations []Registration `json:"registrations,omitempty"`
+}
+
+/**
+ * General parameters to unregister a request or notification.
+ */
+type Unregistration struct {
+
+	// The id used to unregister the request or notification. Usually an id
+	// provided during the register request.
+	Id string `json:"id,omitempty"`
+
+	// The method to unregister for.
+	Method string `json:"method,omitempty"`
+}
+
+type ProgressToken interface{} // number | string
+
+type WorkDoneProgressParams struct {
+
+	// An optional token that a server can use to report work done progress.
+	WorkDoneToken *ProgressToken `json:"workDoneToken,omitempty"`
+}
+
+type PartialResultParams struct {
+
+	// An optional token that a server can use to report partial results (e.g. streaming) to
+	// the client.
+	PartialResultToken *ProgressToken `json:"partialResultToken,omitempty"`
+}
+
+/**
+ * A parameter literal used in requests to pass a text document and a position inside that
+ * document.
+ */
+type TextDocumentPositionParams struct {
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The position inside the text document.
+	Position Position `json:"position,omitempty"`
+}
+
+/**
+ * Workspace specific client capabilities.
+ */
+type WorkspaceClientCapabilities struct {
+
+	// The client supports applying batch edits
+	// to the workspace by supporting the request
+	// 'workspaceapplyEdit'
+	ApplyEdit *bool `json:"applyEdit,omitempty"`
+
+	// Capabilities specific to `WorkspaceEdit`s
+	WorkspaceEdit *WorkspaceEditClientCapabilities `json:"workspaceEdit,omitempty"`
+
+	// Capabilities specific to the `workspacedidChangeConfiguration` notification.
+	DidChangeConfiguration *DidChangeConfigurationClientCapabilities `json:"didChangeConfiguration,omitempty"`
+
+	// Capabilities specific to the `workspacedidChangeWatchedFiles` notification.
+	DidChangeWatchedFiles *DidChangeWatchedFilesClientCapabilities `json:"didChangeWatchedFiles,omitempty"`
+
+	// Capabilities specific to the `workspacesymbol` request.
+	Symbol *WorkspaceSymbolClientCapabilities `json:"symbol,omitempty"`
+
+	// Capabilities specific to the `workspaceexecuteCommand` request.
+	ExecuteCommand *ExecuteCommandClientCapabilities `json:"executeCommand,omitempty"`
+
+	// Capabilities specific to the semantic token requests scoped to the
+	// workspace.
+	//
+	// @since 3.16.0.
+	SemanticTokens *SemanticTokensWorkspaceClientCapabilities `json:"semanticTokens,omitempty"`
+
+	// Capabilities specific to the code lens requests scoped to the
+	// workspace.
+	//
+	// @since 3.16.0.
+	CodeLens *CodeLensWorkspaceClientCapabilities `json:"codeLens,omitempty"`
+
+	// The client has support for file notificationsrequests for user operations on files.
+	//
+	// Since 3.16.0
+	FileOperations *FileOperationClientCapabilities `json:"fileOperations,omitempty"`
+
+	// Capabilities specific to the inline values requests scoped to the
+	// workspace.
+	//
+	// @since 3.17.0.
+	InlineValues *InlineValuesWorkspaceClientCapabilities `json:"inlineValues,omitempty"`
+}
+
+/**
+ * Completion client capabilities
+ */
+type CompletionClientCapabilities struct {
+
+	// Whether completion supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The client supports the following `CompletionItem` specific
+	// capabilities.
+	CompletionItem interface{} `json:"completionItem,omitempty"` //i, n, t, e, r, f, a, c, e, {, },  ,  , /, /,
+
+	CompletionItemKind *struct {
+
+		// The completion item kind values the client supports. When this
+		// property exists the client also guarantees that it will
+		// handle values outside its set gracefully and falls back
+		// to a default value when unknown.
+		//
+		// If this property is not present the client only supports
+		// the completion items kinds from `Text` to `Reference` as defined in
+		// the initial version of the protocol.
+		ValueSet *[]CompletionItemKind `json:"valueSet,omitempty"`
+	} `json:"completionItemKind,omitempty"`
+
+	// Defines how the client handles whitespace and indentation
+	// when accepting a completion item that uses multi line
+	// text in either `insertText` or `textEdit`.
+	//
+	// @since 3.17.0
+	InsertTextMode *InsertTextMode `json:"insertTextMode,omitempty"`
+
+	// The client supports to send additional context information for a
+	// `textDocumentcompletion` request.
+	ContextSupport *bool `json:"contextSupport,omitempty"`
+}
+
+/**
+ * Text document specific client capabilities.
+ */
+type TextDocumentClientCapabilities struct {
+
+	// Defines which synchronization capabilities the client supports.
+	Synchronization *TextDocumentSyncClientCapabilities `json:"synchronization,omitempty"`
+
+	// Capabilities specific to the `textDocumentcompletion`
+	Completion *CompletionClientCapabilities `json:"completion,omitempty"`
+
+	// Capabilities specific to the `textDocumenthover`
+	Hover *HoverClientCapabilities `json:"hover,omitempty"`
+
+	// Capabilities specific to the `textDocumentsignatureHelp`
+	SignatureHelp *SignatureHelpClientCapabilities `json:"signatureHelp,omitempty"`
+
+	// Capabilities specific to the `textDocumentdeclaration`
+	//
+	// @since 3.14.0
+	Declaration *DeclarationClientCapabilities `json:"declaration,omitempty"`
+
+	// Capabilities specific to the `textDocumentdefinition`
+	Definition *DefinitionClientCapabilities `json:"definition,omitempty"`
+
+	// Capabilities specific to the `textDocumenttypeDefinition`
+	//
+	// @since 3.6.0
+	TypeDefinition *TypeDefinitionClientCapabilities `json:"typeDefinition,omitempty"`
+
+	// Capabilities specific to the `textDocumentimplementation`
+	//
+	// @since 3.6.0
+	Implementation *ImplementationClientCapabilities `json:"implementation,omitempty"`
+
+	// Capabilities specific to the `textDocumentreferences`
+	References *ReferenceClientCapabilities `json:"references,omitempty"`
+
+	// Capabilities specific to the `textDocumentdocumentHighlight`
+	DocumentHighlight *DocumentHighlightClientCapabilities `json:"documentHighlight,omitempty"`
+
+	// Capabilities specific to the `textDocumentdocumentSymbol`
+	DocumentSymbol *DocumentSymbolClientCapabilities `json:"documentSymbol,omitempty"`
+
+	// Capabilities specific to the `textDocumentcodeAction`
+	CodeAction *CodeActionClientCapabilities `json:"codeAction,omitempty"`
+
+	// Capabilities specific to the `textDocumentcodeLens`
+	CodeLens *CodeLensClientCapabilities `json:"codeLens,omitempty"`
+
+	// Capabilities specific to the `textDocumentdocumentLink`
+	DocumentLink *DocumentLinkClientCapabilities `json:"documentLink,omitempty"`
+
+	// Capabilities specific to the `textDocumentdocumentColor`
+	ColorProvider *DocumentColorClientCapabilities `json:"colorProvider,omitempty"`
+
+	// Capabilities specific to the `textDocumentformatting`
+	Formatting *DocumentFormattingClientCapabilities `json:"formatting,omitempty"`
+
+	// Capabilities specific to the `textDocumentrangeFormatting`
+	RangeFormatting *DocumentRangeFormattingClientCapabilities `json:"rangeFormatting,omitempty"`
+
+	// Capabilities specific to the `textDocumentonTypeFormatting`
+	OnTypeFormatting *DocumentOnTypeFormattingClientCapabilities `json:"onTypeFormatting,omitempty"`
+
+	// Capabilities specific to the `textDocumentrename`
+	Rename *RenameClientCapabilities `json:"rename,omitempty"`
+
+	// Capabilities specific to `textDocumentfoldingRange` request.
+	//
+	// @since 3.10.0
+	FoldingRange *FoldingRangeClientCapabilities `json:"foldingRange,omitempty"`
+
+	// Capabilities specific to `textDocumentselectionRange` request.
+	//
+	// @since 3.15.0
+	SelectionRange *SelectionRangeClientCapabilities `json:"selectionRange,omitempty"`
+
+	// Capabilities specific to `textDocumentpublishDiagnostics` notification.
+	PublishDiagnostics *PublishDiagnosticsClientCapabilities `json:"publishDiagnostics,omitempty"`
+
+	// Capabilities specific to the various call hierarchy request.
+	//
+	// @since 3.16.0
+	CallHierarchy *CallHierarchyClientCapabilities `json:"callHierarchy,omitempty"`
+
+	// Capabilities specific to the various semantic token request.
+	//
+	// @since 3.16.0
+	SemanticTokens *SemanticTokensClientCapabilities `json:"semanticTokens,omitempty"`
+
+	// Capabilities specific to the linked editing range request.
+	//
+	// @since 3.16.0
+	LinkedEditingRange *LinkedEditingRangeClientCapabilities `json:"linkedEditingRange,omitempty"`
+
+	// Client capabilities specific to the moniker request.
+	//
+	// @since 3.16.0
+	Moniker *MonikerClientCapabilities `json:"moniker,omitempty"`
+
+	// Capabilities specific to the various type hierarchy requests.
+	//
+	// @since 3.17.0 - proposed state
+	TypeHierarchy *TypeHierarchyClientCapabilities `json:"typeHierarchy,omitempty"`
+
+	// Capabilities specific to the `textDocumentinlineValues` request.
+	//
+	// @since 3.17.0 - proposed state
+	InlineValues *InlineValuesClientCapabilities `json:"inlineValues,omitempty"`
+}
+
+type WindowClientCapabilities struct {
+
+	// Whether client supports handling progress notifications. If set
+	// servers are allowed to report in `workDoneProgress` property in the
+	// request specific server capabilities.
+	//
+	// @since 3.15.0
+	WorkDoneProgress *bool `json:"workDoneProgress,omitempty"`
+
+	// Capabilities specific to the showMessage request.
+	//
+	// @since 3.16.0
+	ShowMessage *ShowMessageRequestClientCapabilities `json:"showMessage,omitempty"`
+
+	// Capabilities specific to the showDocument request.
+	//
+	// @since 3.16.0
+	ShowDocument *ShowDocumentClientCapabilities `json:"showDocument,omitempty"`
+}
+
+/**
+ * Client capabilities specific to regular expressions.
+ *
+ * @since 3.16.0
+ */
+type RegularExpressionsClientCapabilities struct {
+
+	// The engine's name.
+	Engine string `json:"engine,omitempty"`
+
+	// The engine's version.
+	Version *string `json:"version,omitempty"`
+}
+
+/**
+ * Client capabilities specific to the used markdown parser.
+ *
+ * @since 3.16.0
+ */
+type MarkdownClientCapabilities struct {
+
+	// The name of the parser.
+	Parser string `json:"parser,omitempty"`
+
+	// The version of the parser.
+	Version *string `json:"version,omitempty"`
+}
+
+/**
+ * General client capabilities.
+ *
+ * @since 3.16.0
+ */
+type GeneralClientCapabilities struct {
+
+	// Client capability that signals how the client
+	// handles stale requests (e.g. a request
+	// for which the client will not process the response
+	// anymore since the information is outdated).
+	//
+	// @since 3.17.0
+	StaleRequestSupport interface{} `json:"staleRequestSupport,omitempty"` // cancel, retryOnContentModified,
+
+	// Client capabilities specific to regular expressions.
+	//
+	// @since 3.16.0
+	RegularExpressions *RegularExpressionsClientCapabilities `json:"regularExpressions,omitempty"`
+
+	// Client capabilities specific to the client's markdown parser.
+	//
+	// @since 3.16.0
+	Markdown *MarkdownClientCapabilities `json:"markdown,omitempty"`
+}
+
+/**
+ * Defines the capabilities provided by the client.
+ */
+type _ClientCapabilities struct {
+
+	// Workspace specific client capabilities.
+	Workspace *WorkspaceClientCapabilities `json:"workspace,omitempty"`
+
+	// Text document specific client capabilities.
+	TextDocument *TextDocumentClientCapabilities `json:"textDocument,omitempty"`
+
+	// Window specific client capabilities.
+	Window *WindowClientCapabilities `json:"window,omitempty"`
+
+	// General client capabilities.
+	//
+	// @since 3.16.0
+	General *GeneralClientCapabilities `json:"general,omitempty"`
+
+	// Experimental client capabilities.
+	Experimental interface{} `json:"experimental,omitempty"`
+}
+
+/**
+ * Static registration options to be returned in the initialize
+ * request.
+ */
+type StaticRegistrationOptions struct {
+
+	// The id used to register the request. The id can be used to deregister
+	// the request again. See also Registration#id.
+	Id *string `json:"id,omitempty"`
+}
+
+/**
+ * General text document registration options.
+ */
+type TextDocumentRegistrationOptions struct {
+
+	// A document selector to identify the scope of the registration. If set to null
+	// the document selector provided on the client side will be used.
+	DocumentSelector interface{} `json:"documentSelector,omitempty"` // DocumentSelector, null,
+}
+
+/**
+ * Save options.
+ */
+type SaveOptions struct {
+
+	// The client is supposed to include the content on save.
+	IncludeText *bool `json:"includeText,omitempty"`
+}
+
+type WorkDoneProgressOptions struct {
+	WorkDoneProgress *bool `json:"workDoneProgress,omitempty"`
+}
+
+/**
+ * The result returned from an initialize request.
+ */
+type InitializeResult struct {
+
+	// The capabilities the language server provides.
+	Capabilities ServerCapabilities `json:"capabilities,omitempty"`
+
+	// Information about the server.
+	//
+	// @since 3.15.0
+	ServerInfo *struct {
+		Name    string  `json:"name,omitempty"`
+		Version *string `json:"version,omitempty"`
+	} `json:"serverInfo,omitempty"` // name, version,
+
+	// Custom initialization results.
+	Custom interface{} `json:"custom,omitempty"`
+}
+
+/**
+ * The initialize parameters
+ */
+type _InitializeParams struct {
+	WorkDoneProgressParams
+
+	// The process Id of the parent process that started
+	// the server.
+	ProcessId interface{} `json:"processId,omitempty"` // int, null,
+
+	// Information about the client
+	//
+	// @since 3.15.0
+	ClientInfo interface{} `json:"clientInfo,omitempty"` // name, version,
+
+	// The locale the client is currently showing the user interface
+	// in. This must not necessarily be the locale of the operating
+	// system.
+	//
+	// Uses IETF language tags as the value's syntax
+	// (See https:en.wikipedia.orgwikiIETF_language_tag)
+	//
+	// @since 3.16.0
+	Locale *string `json:"locale,omitempty"`
+
+	// The rootPath of the workspace. Is null
+	// if no folder is open.
+	//
+	// @deprecated in favour of rootUri.
+	RootPath interface{} `json:"rootPath,omitempty"` // string, null,
+
+	// The rootUri of the workspace. Is null if no
+	// folder is open. If both `rootPath` and `rootUri` are set
+	// `rootUri` wins.
+	//
+	// @deprecated in favour of workspaceFolders.
+	RootUri interface{} `json:"rootUri,omitempty"` // DocumentUri, null,
+
+	// The capabilities provided by the client (editor or tool)
+	Capabilities ClientCapabilities `json:"capabilities,omitempty"`
+
+	// User provided initialization options.
+	InitializationOptions interface{} `json:"initializationOptions,omitempty"`
+
+	// The initial trace setting. If omitted trace is disabled ('off').
+	Trace interface{} `json:"trace,omitempty"` // interface{} // 'off', interface{} // 'messages', interface{} // 'compact', interface{} // 'verbose',
+}
+
+/**
+ * The data type of the ResponseError if the
+ * initialize request fails.
+ */
+type InitializeError struct {
+
+	// Indicates whether the client execute the following retry logic:
+	// (1) show the message provided by the ResponseError to the user
+	// (2) user selects retry or cancel
+	// (3) if user selected retry the initialize method is sent again.
+	Retry bool `json:"retry,omitempty"`
+}
+
+// ---- Configuration notification ----
+type DidChangeConfigurationClientCapabilities struct {
+
+	// Did change configuration notification supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+type DidChangeConfigurationRegistrationOptions struct {
+	Section interface{} `json:"section,omitempty"` // string, []string,
+}
+
+/**
+ * The parameters of a change configuration notification.
+ */
+type DidChangeConfigurationParams struct {
+
+	// The actual changed settings
+	Settings interface{} `json:"settings,omitempty"`
+}
+
+/**
+ * The parameters of a notification message.
+ */
+type ShowMessageParams struct {
+
+	// The message type. See {@link MessageType}
+	Type MessageType `json:"type,omitempty"`
+
+	// The actual message
+	Message string `json:"message,omitempty"`
+}
+
+/**
+ * Show message request client capabilities
+ */
+type ShowMessageRequestClientCapabilities struct {
+
+	// Capabilities specific to the `MessageActionItem` type.
+	MessageActionItem *struct {
+
+		// Whether the client supports additional attributes which
+		// are preserved and send back to the server in the
+		// request's response.
+		AdditionalPropertiesSupport *bool `json:"additionalPropertiesSupport,omitempty"`
+	} `json:"messageActionItem,omitempty"`
+}
+
+type MessageActionItem struct {
+
+	// A short title like 'Retry', 'Open Log' etc.
+	Title string `json:"title,omitempty"`
+
+	// Additional attributes that the client preserves and
+	// sends back to the server. This depends on the client
+	// capability window.messageActionItem.additionalPropertiesSupport
+	Key interface{} `json:"key,omitempty"` // string, bool, int, interface{},
+}
+
+type ShowMessageRequestParams struct {
+
+	// The message type. See {@link MessageType}
+	Type MessageType `json:"type,omitempty"`
+
+	// The actual message
+	Message string `json:"message,omitempty"`
+
+	// The message action items to present.
+	Actions *[]MessageActionItem `json:"actions,omitempty"`
+}
+
+/**
+ * The logs message parameters.
+ */
+type LogMessageParams struct {
+
+	// The message type. See {@link MessageType}
+	Type MessageType `json:"type,omitempty"`
+
+	// The actual message
+	Message string `json:"message,omitempty"`
+}
+
+// ---- Text document notifications ----
+type TextDocumentSyncClientCapabilities struct {
+
+	// Whether text document synchronization supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The client supports sending will save notifications.
+	WillSave *bool `json:"willSave,omitempty"`
+
+	// The client supports sending a will save request and
+	// waits for a response providing text edits which will
+	// be applied to the document before it is saved.
+	WillSaveWaitUntil *bool `json:"willSaveWaitUntil,omitempty"`
+
+	// The client supports did save notifications.
+	DidSave *bool `json:"didSave,omitempty"`
+}
+
+type TextDocumentSyncOptions struct {
+
+	// Open and close notifications are sent to the server. If omitted open close notification should not
+	// be sent.
+	OpenClose *bool `json:"openClose,omitempty"`
+
+	// Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+	// and TextDocumentSyncKind.Incremental. If omitted it defaults to TextDocumentSyncKind.None.
+	Change *TextDocumentSyncKind `json:"change,omitempty"`
+
+	// If present will save notifications are sent to the server. If omitted the notification should not be
+	// sent.
+	WillSave *bool `json:"willSave,omitempty"`
+
+	// If present will save wait until requests are sent to the server. If omitted the request should not be
+	// sent.
+	WillSaveWaitUntil *bool `json:"willSaveWaitUntil,omitempty"`
+
+	// If present save notifications are sent to the server. If omitted the notification should not be
+	// sent.
+	Save interface{} `json:"save,omitempty"` // bool, SaveOptions,
+}
+
+/**
+ * The parameters send in a open text document notification
+ */
+type DidOpenTextDocumentParams struct {
+
+	// The document that was opened.
+	TextDocument TextDocumentItem `json:"textDocument,omitempty"`
+}
+
+/**
+ * The change text document notification's parameters.
+ */
+type DidChangeTextDocumentParams struct {
+
+	// The document that did change. The version number points
+	// to the version after all provided content changes have
+	// been applied.
+	TextDocument VersionedTextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The actual content changes. The content changes describe single state changes
+	// to the document. So if there are two content changes c1 (at array index 0) and
+	// c2 (at array index 1) for a document in state S then c1 moves the document from
+	// S to S' and c2 from S' to S''. So c1 is computed on the state S and c2 is computed
+	// on the state S'.
+	//
+	// To mirror the content of a document using change events use the following approach:
+	// - start with the same initial content
+	// - apply the 'textDocumentdidChange' notifications in the order you receive them.
+	// - apply the `TextDocumentContentChangeEvent`s in a single notification in the order
+	// you receive them.
+	ContentChanges []TextDocumentContentChangeEvent `json:"contentChanges,omitempty"`
+}
+
+/**
+ * An event describing a change to a text document. If range and rangeLength are omitted
+ * the new text is considered to be the full content of the document.
+ */
+type TextDocumentContentChangeEvent struct {
+
+	// The range of the document that changed.
+	Range Range `json:"range,omitempty"`
+
+	// The optional length of the range that got replaced.
+	//
+	// @deprecated use range instead.
+	RangeLength *uint `json:"rangeLength,omitempty"`
+
+	// The new text for the provided range.
+	Text interface{} `json:"text,omitempty"` // string, {"text": string}
+}
+
+/**
+ * Describe options to be used when registered for text document change events.
+ */
+type TextDocumentChangeRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+
+	// How documents are synced to the server.
+	SyncKind TextDocumentSyncKind `json:"syncKind,omitempty"`
+}
+
+/**
+ * The parameters send in a close text document notification
+ */
+type DidCloseTextDocumentParams struct {
+
+	// The document that was closed.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+}
+
+/**
+ * The parameters send in a save text document notification
+ */
+type DidSaveTextDocumentParams struct {
+
+	// The document that was closed.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// Optional the content when saved. Depends on the includeText value
+	// when the save notification was requested.
+	Text *string `json:"text,omitempty"`
+}
+
+/**
+ * Save registration options.
+ */
+type TextDocumentSaveRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	SaveOptions
+}
+
+/**
+ * The parameters send in a will save text document notification.
+ */
+type WillSaveTextDocumentParams struct {
+
+	// The document that will be saved.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The 'TextDocumentSaveReason'.
+	Reason TextDocumentSaveReason `json:"reason,omitempty"`
+}
+
+// ---- File eventing ----
+type DidChangeWatchedFilesClientCapabilities struct {
+
+	// Did change watched files notification supports dynamic registration. Please note
+	// that the current protocol doesn't support static configuration for file changes
+	// from the server side.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * The watched files change notification's parameters.
+ */
+type DidChangeWatchedFilesParams struct {
+
+	// The actual file events.
+	Changes []FileEvent `json:"changes,omitempty"`
+}
+
+/**
+ * An event describing a file change.
+ */
+type FileEvent struct {
+
+	// The file's uri.
+	Uri DocumentUri `json:"uri,omitempty"`
+
+	// The change type.
+	Type FileChangeType `json:"type,omitempty"`
+}
+
+/**
+ * Describe options to be used when registered for text document change events.
+ */
+type DidChangeWatchedFilesRegistrationOptions struct {
+
+	// The watchers to register.
+	Watchers []FileSystemWatcher `json:"watchers,omitempty"`
+}
+
+type FileSystemWatcher struct {
+
+	// The  glob pattern to watch. Glob patterns can have the following syntax:
+	// - `` to match one or more characters in a path segment
+	// - `?` to match on one character in a path segment
+	// - `` to match any number of path segments, including none
+	// - `{}` to group conditions (e.g. `​.{ts,js}` matches all TypeScript and JavaScript files)
+	// - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+	// - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+	GlobPattern string `json:"globPattern,omitempty"`
+
+	// The kind of events of interest. If omitted it defaults
+	// to WatchKind.Create | WatchKind.Change | WatchKind.Delete
+	// which is 7.
+	Kind *uint `json:"kind,omitempty"`
+}
+
+/**
+ * The publish diagnostic client capabilities.
+ */
+type PublishDiagnosticsClientCapabilities struct {
+
+	// Whether the clients accepts diagnostics with related information.
+	RelatedInformation *bool `json:"relatedInformation,omitempty"`
+
+	// Client supports the tag property to provide meta data about a diagnostic.
+	// Clients supporting tags have to handle unknown tags gracefully.
+	//
+	// @since 3.15.0
+	TagSupport *struct {
+
+		// The tags supported by the client.
+		ValueSet []DiagnosticTag `json:"valueSet,omitempty"`
+	} `json:"tagSupport,omitempty"`
+
+	// Whether the client interprets the version property of the
+	// `textDocumentpublishDiagnostics` notification`s parameter.
+	//
+	// @since 3.15.0
+	VersionSupport *bool `json:"versionSupport,omitempty"`
+
+	// Client supports a codeDescription property
+	//
+	// @since 3.16.0
+	CodeDescriptionSupport *bool `json:"codeDescriptionSupport,omitempty"`
+
+	// Whether code action supports the `data` property which is
+	// preserved between a `textDocumentpublishDiagnostics` and
+	// `textDocumentcodeAction` request.
+	//
+	// @since 3.16.0
+	DataSupport *bool `json:"dataSupport,omitempty"`
+}
+
+/**
+ * The publish diagnostic notification's parameters.
+ */
+type PublishDiagnosticsParams struct {
+
+	// The URI for which diagnostic information is reported.
+	Uri DocumentUri `json:"uri,omitempty"`
+
+	// Optional the version number of the document the diagnostics are published for.
+	//
+	// @since 3.15.0
+	Version *int `json:"version,omitempty"`
+
+	// An array of diagnostic information items.
+	Diagnostics []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+/**
+ * Contains additional information about the context in which a completion request is triggered.
+ */
+type CompletionContext struct {
+
+	// How the completion was triggered.
+	TriggerKind CompletionTriggerKind `json:"triggerKind,omitempty"`
+
+	// The trigger character (a single character) that has trigger code complete.
+	// Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+	TriggerCharacter *string `json:"triggerCharacter,omitempty"`
+}
+
+/**
+ * Completion parameters
+ */
+type CompletionParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The completion context. This is only available it the client specifies
+	// to send this using the client capability `textDocument.completion.contextSupport === true`
+	Context *CompletionContext `json:"context,omitempty"`
+}
+
+/**
+ * Completion options.
+ */
+type CompletionOptions struct {
+	WorkDoneProgressOptions
+
+	// Most tools trigger completion request automatically without explicitly requesting
+	// it using a keyboard shortcut (e.g. Ctrl+Space). Typically they do so when the user
+	// starts to type an identifier. For example if the user types `c` in a JavaScript file
+	// code complete will automatically pop up present `console` besides others as a
+	// completion item. Characters that make up identifiers don't need to be listed here.
+	//
+	// If code complete should automatically be trigger on characters not being valid inside
+	// an identifier (for example `.` in JavaScript) list them in `triggerCharacters`.
+	TriggerCharacters *[]string `json:"triggerCharacters,omitempty"`
+
+	// The list of all possible characters that commit a completion. This field can be used
+	// if clients don't support individual commit characters per completion item. See
+	// `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`
+	//
+	// If a server provides both `allCommitCharacters` and commit characters on an individual
+	// completion item the ones on the completion item win.
+	//
+	// @since 3.2.0
+	AllCommitCharacters *[]string `json:"allCommitCharacters,omitempty"`
+
+	// The server provides support to resolve additional
+	// information for a completion item.
+	ResolveProvider *bool `json:"resolveProvider,omitempty"`
+
+	// The server supports the following `CompletionItem` specific
+	// capabilities.
+	//
+	// @since 3.17.0 - proposed state
+	CompletionItem *struct {
+
+		// The server has support for completion item label
+		// details (see also `CompletionItemLabelDetails`) when
+		// receiving a completion item in a resolve call.
+		//
+		// @since 3.17.0 - proposed state
+		LabelDetailsSupport *bool `json:"labelDetailsSupport,omitempty"`
+	} `json:"completionItem,omitempty"`
+}
+
+/**
+ * Registration options for a [CompletionRequest](#CompletionRequest).
+ */
+type CompletionRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	CompletionOptions
+}
+
+// ---- Hover Support -------------------------------
+type HoverClientCapabilities struct {
+
+	// Whether hover supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// Client supports the follow content formats for the content
+	// property. The order describes the preferred format of the client.
+	ContentFormat *[]MarkupKind `json:"contentFormat,omitempty"`
+}
+
+/**
+ * Hover options.
+ */
+type HoverOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Parameters for a [HoverRequest](#HoverRequest).
+ */
+type HoverParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+}
+
+/**
+ * Registration options for a [HoverRequest](#HoverRequest).
+ */
+type HoverRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	HoverOptions
+}
+
+/**
+ * Client Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest).
+ */
+type SignatureHelpClientCapabilities struct {
+
+	// Whether signature help supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The client supports the following `SignatureInformation`
+	// specific properties.
+	SignatureInformation interface{} `json:"signatureInformation,omitempty"` // documentationFormat, parameterInformation, activeParameterSupport,
+
+	// The client supports to send additional context information for a
+	// `textDocumentsignatureHelp` request. A client that opts into
+	// contextSupport will also support the `retriggerCharacters` on
+	// `SignatureHelpOptions`.
+	//
+	// @since 3.15.0
+	ContextSupport *bool `json:"contextSupport,omitempty"`
+}
+
+/**
+ * Server Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest).
+ */
+type SignatureHelpOptions struct {
+	WorkDoneProgressOptions
+
+	// List of characters that trigger signature help.
+	TriggerCharacters *[]string `json:"triggerCharacters,omitempty"`
+
+	// List of characters that re-trigger signature help.
+	//
+	// These trigger characters are only active when signature help is already showing. All trigger characters
+	// are also counted as re-trigger characters.
+	//
+	// @since 3.15.0
+	RetriggerCharacters *[]string `json:"retriggerCharacters,omitempty"`
+}
+
+/**
+ * Additional information about the context in which a signature help request was triggered.
+ *
+ * @since 3.15.0
+ */
+type SignatureHelpContext struct {
+
+	// Action that caused signature help to be triggered.
+	TriggerKind SignatureHelpTriggerKind `json:"triggerKind,omitempty"`
+
+	// Character that caused signature help to be triggered.
+	//
+	// This is undefined when `triggerKind !== SignatureHelpTriggerKind.TriggerCharacter`
+	TriggerCharacter *string `json:"triggerCharacter,omitempty"`
+
+	// `true` if signature help was already showing when it was triggered.
+	//
+	// Retrigger occurs when the signature help is already active and can be caused by actions such as
+	// typing a trigger character, a cursor move, or document content changes.
+	IsRetrigger bool `json:"isRetrigger,omitempty"`
+
+	// The currently active `SignatureHelp`.
+	//
+	// The `activeSignatureHelp` has its `SignatureHelp.activeSignature` field updated based on
+	// the user navigating through available signatures.
+	ActiveSignatureHelp *SignatureHelp `json:"activeSignatureHelp,omitempty"`
+}
+
+/**
+ * Parameters for a [SignatureHelpRequest](#SignatureHelpRequest).
+ */
+type SignatureHelpParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+
+	// The signature help context. This is only available if the client specifies
+	// to send this using the client capability `textDocument.signatureHelp.contextSupport === true`
+	//
+	// @since 3.15.0
+	Context *SignatureHelpContext `json:"context,omitempty"`
+}
+
+/**
+ * Registration options for a [SignatureHelpRequest](#SignatureHelpRequest).
+ */
+type SignatureHelpRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	SignatureHelpOptions
+}
+
+/**
+ * Client Capabilities for a [DefinitionRequest](#DefinitionRequest).
+ */
+type DefinitionClientCapabilities struct {
+
+	// Whether definition supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The client supports additional metadata in the form of definition links.
+	//
+	// @since 3.14.0
+	LinkSupport *bool `json:"linkSupport,omitempty"`
+}
+
+/**
+ * Server Capabilities for a [DefinitionRequest](#DefinitionRequest).
+ */
+type DefinitionOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Parameters for a [DefinitionRequest](#DefinitionRequest).
+ */
+type DefinitionParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+	PartialResultParams
+}
+
+/**
+ * Registration options for a [DefinitionRequest](#DefinitionRequest).
+ */
+type DefinitionRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	DefinitionOptions
+}
+
+/**
+ * Client Capabilities for a [ReferencesRequest](#ReferencesRequest).
+ */
+type ReferenceClientCapabilities struct {
+
+	// Whether references supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * Parameters for a [ReferencesRequest](#ReferencesRequest).
+ */
+type ReferenceParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+	PartialResultParams
+
+	Context ReferenceContext `json:"context,omitempty"`
+}
+
+/**
+ * Reference options.
+ */
+type ReferenceOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Registration options for a [ReferencesRequest](#ReferencesRequest).
+ */
+type ReferenceRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	ReferenceOptions
+}
+
+/**
+ * Client Capabilities for a [DocumentHighlightRequest](#DocumentHighlightRequest).
+ */
+type DocumentHighlightClientCapabilities struct {
+
+	// Whether document highlight supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * Parameters for a [DocumentHighlightRequest](#DocumentHighlightRequest).
+ */
+type DocumentHighlightParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+	PartialResultParams
+}
+
+/**
+ * Provider options for a [DocumentHighlightRequest](#DocumentHighlightRequest).
+ */
+type DocumentHighlightOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Registration options for a [DocumentHighlightRequest](#DocumentHighlightRequest).
+ */
+type DocumentHighlightRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	DocumentHighlightOptions
+}
+
+/**
+ * Client Capabilities for a [DocumentSymbolRequest](#DocumentSymbolRequest).
+ */
+type DocumentSymbolClientCapabilities struct {
+
+	// Whether document symbol supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// Specific capabilities for the `SymbolKind`.
+	SymbolKind *struct {
+
+		// The symbol kind values the client supports. When this
+		// property exists the client also guarantees that it will
+		// handle values outside its set gracefully and falls back
+		// to a default value when unknown.
+		//
+		// If this property is not present the client only supports
+		// the symbol kinds from `File` to `Array` as defined in
+		// the initial version of the protocol.
+		ValueSet *[]SymbolKind `json:"valueSet,omitempty"`
+	} `json:"symbolKind,omitempty"`
+
+	// The client support hierarchical document symbols.
+	HierarchicalDocumentSymbolSupport *bool `json:"hierarchicalDocumentSymbolSupport,omitempty"`
+
+	// The client supports tags on `SymbolInformation`. Tags are supported on
+	// `DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.
+	// Clients supporting tags have to handle unknown tags gracefully.
+	//
+	// @since 3.16.0
+	TagSupport *struct {
+
+		// The tags supported by the client.
+		ValueSet []SymbolTag `json:"valueSet,omitempty"`
+	} `json:"tagSupport,omitempty"`
+
+	// The client supports an additional label presented in the UI when
+	// registering a document symbol provider.
+	//
+	// @since 3.16.0
+	LabelSupport *bool `json:"labelSupport,omitempty"`
+}
+
+/**
+ * Parameters for a [DocumentSymbolRequest](#DocumentSymbolRequest).
+ */
+type DocumentSymbolParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+}
+
+/**
+ * Provider options for a [DocumentSymbolRequest](#DocumentSymbolRequest).
+ */
+type DocumentSymbolOptions struct {
+	WorkDoneProgressOptions
+
+	// A human-readable string that is shown when multiple outlines trees
+	// are shown for the same document.
+	//
+	// @since 3.16.0
+	Label *string `json:"label,omitempty"`
+}
+
+/**
+ * Registration options for a [DocumentSymbolRequest](#DocumentSymbolRequest).
+ */
+type DocumentSymbolRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	DocumentSymbolOptions
+}
+
+/**
+ * The Client Capabilities of a [CodeActionRequest](#CodeActionRequest).
+ */
+type CodeActionClientCapabilities struct {
+
+	// Whether code action supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The client support code action literals of type `CodeAction` as a valid
+	// response of the `textDocumentcodeAction` request. If the property is not
+	// set the request can only return `Command` literals.
+	//
+	// @since 3.8.0
+	CodeActionLiteralSupport *struct {
+
+		// The code action kind is support with the following value
+		// set.
+		CodeActionKind struct {
+
+			// The code action kind values the client supports. When this
+			// property exists the client also guarantees that it will
+			// handle values outside its set gracefully and falls back
+			// to a default value when unknown.
+			ValueSet []CodeActionKind `json:"valueSet,omitempty"`
+		} `json:"codeActionKind,omitempty"`
+	} `json:"codeActionLiteralSupport,omitempty"`
+
+	// Whether code action supports the `isPreferred` property.
+	//
+	// @since 3.15.0
+	IsPreferredSupport *bool `json:"isPreferredSupport,omitempty"`
+
+	// Whether code action supports the `disabled` property.
+	//
+	// @since 3.16.0
+	DisabledSupport *bool `json:"disabledSupport,omitempty"`
+
+	// Whether code action supports the `data` property which is
+	// preserved between a `textDocumentcodeAction` and a
+	// `codeActionresolve` request.
+	//
+	// @since 3.16.0
+	DataSupport *bool `json:"dataSupport,omitempty"`
+
+	// Whether the client support resolving additional code action
+	// properties via a separate `codeActionresolve` request.
+	//
+	// @since 3.16.0
+	ResolveSupport *struct {
+
+		// The properties that a client can resolve lazily.
+		Properties []string `json:"properties,omitempty"`
+	} `json:"resolveSupport,omitempty"`
+
+	// Whether th client honors the change annotations in
+	// text edits and resource operations returned via the
+	// `CodeAction#edit` property by for example presenting
+	// the workspace edit in the user interface and asking
+	// for confirmation.
+	//
+	// @since 3.16.0
+	HonorsChangeAnnotations *bool `json:"honorsChangeAnnotations,omitempty"`
+}
+
+/**
+ * The parameters of a [CodeActionRequest](#CodeActionRequest).
+ */
+type CodeActionParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The document in which the command was invoked.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The range for which the command was invoked.
+	Range Range `json:"range,omitempty"`
+
+	// Context carrying additional information.
+	Context CodeActionContext `json:"context,omitempty"`
+}
+
+/**
+ * Provider options for a [CodeActionRequest](#CodeActionRequest).
+ */
+type CodeActionOptions struct {
+	WorkDoneProgressOptions
+
+	// CodeActionKinds that this server may return.
+	//
+	// The list of kinds may be generic, such as `CodeActionKind.Refactor`, or the server
+	// may list out every specific kind they provide.
+	CodeActionKinds *[]CodeActionKind `json:"codeActionKinds,omitempty"`
+
+	// The server provides support to resolve additional
+	// information for a code action.
+	//
+	// @since 3.16.0
+	ResolveProvider *bool `json:"resolveProvider,omitempty"`
+}
+
+/**
+ * Registration options for a [CodeActionRequest](#CodeActionRequest).
+ */
+type CodeActionRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	CodeActionOptions
+}
+
+/**
+ * Client capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
+ */
+type WorkspaceSymbolClientCapabilities struct {
+
+	// Symbol request supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// Specific capabilities for the `SymbolKind` in the `workspacesymbol` request.
+	SymbolKind *struct {
+
+		// The symbol kind values the client supports. When this
+		// property exists the client also guarantees that it will
+		// handle values outside its set gracefully and falls back
+		// to a default value when unknown.
+		//
+		// If this property is not present the client only supports
+		// the symbol kinds from `File` to `Array` as defined in
+		// the initial version of the protocol.
+		ValueSet *[]SymbolKind `json:"valueSet,omitempty"`
+	} `json:"symbolKind,omitempty"`
+
+	// The client supports tags on `SymbolInformation`.
+	// Clients supporting tags have to handle unknown tags gracefully.
+	//
+	// @since 3.16.0
+	TagSupport *struct {
+
+		// The tags supported by the client.
+		ValueSet []SymbolTag `json:"valueSet,omitempty"`
+	} `json:"tagSupport,omitempty"`
+}
+
+/**
+ * The parameters of a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
+ */
+type WorkspaceSymbolParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// A query string to filter symbols by. Clients may send an empty
+	// string here to request all symbols.
+	Query string `json:"query,omitempty"`
+}
+
+/**
+ * Server capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
+ */
+type WorkspaceSymbolOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Registration options for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
+ */
+type WorkspaceSymbolRegistrationOptions struct {
+	WorkspaceSymbolOptions
+}
+
+/**
+ * The client capabilities  of a [CodeLensRequest](#CodeLensRequest).
+ */
+type CodeLensClientCapabilities struct {
+
+	// Whether code lens supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type CodeLensWorkspaceClientCapabilities struct {
+
+	// Whether the client implementation supports a refresh request sent from the
+	// server to the client.
+	//
+	// Note that this event is global and will force the client to refresh all
+	// code lenses currently shown. It should be used with absolute care and is
+	// useful for situation where a server for example detect a project wide
+	// change that requires such a calculation.
+	RefreshSupport *bool `json:"refreshSupport,omitempty"`
+}
+
+/**
+ * The parameters of a [CodeLensRequest](#CodeLensRequest).
+ */
+type CodeLensParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The document to request code lens for.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+}
+
+/**
+ * Code Lens provider options of a [CodeLensRequest](#CodeLensRequest).
+ */
+type CodeLensOptions struct {
+	WorkDoneProgressOptions
+
+	// Code lens has a resolve provider as well.
+	ResolveProvider *bool `json:"resolveProvider,omitempty"`
+}
+
+/**
+ * Registration options for a [CodeLensRequest](#CodeLensRequest).
+ */
+type CodeLensRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	CodeLensOptions
+}
+
+/**
+ * The client capabilities of a [DocumentLinkRequest](#DocumentLinkRequest).
+ */
+type DocumentLinkClientCapabilities struct {
+
+	// Whether document link supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// Whether the client support the `tooltip` property on `DocumentLink`.
+	//
+	// @since 3.15.0
+	TooltipSupport *bool `json:"tooltipSupport,omitempty"`
+}
+
+/**
+ * The parameters of a [DocumentLinkRequest](#DocumentLinkRequest).
+ */
+type DocumentLinkParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The document to provide document links for.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+}
+
+/**
+ * Provider options for a [DocumentLinkRequest](#DocumentLinkRequest).
+ */
+type DocumentLinkOptions struct {
+	WorkDoneProgressOptions
+
+	// Document links have a resolve provider as well.
+	ResolveProvider *bool `json:"resolveProvider,omitempty"`
+}
+
+/**
+ * Registration options for a [DocumentLinkRequest](#DocumentLinkRequest).
+ */
+type DocumentLinkRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	DocumentLinkOptions
+}
+
+/**
+ * Client capabilities of a [DocumentFormattingRequest](#DocumentFormattingRequest).
+ */
+type DocumentFormattingClientCapabilities struct {
+
+	// Whether formatting supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * The parameters of a [DocumentFormattingRequest](#DocumentFormattingRequest).
+ */
+type DocumentFormattingParams struct {
+	WorkDoneProgressParams
+
+	// The document to format.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The format options
+	Options FormattingOptions `json:"options,omitempty"`
+}
+
+/**
+ * Provider options for a [DocumentFormattingRequest](#DocumentFormattingRequest).
+ */
+type DocumentFormattingOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Registration options for a [DocumentFormattingRequest](#DocumentFormattingRequest).
+ */
+type DocumentFormattingRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	DocumentFormattingOptions
+}
+
+/**
+ * Client capabilities of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest).
+ */
+type DocumentRangeFormattingClientCapabilities struct {
+
+	// Whether range formatting supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * The parameters of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest).
+ */
+type DocumentRangeFormattingParams struct {
+	WorkDoneProgressParams
+
+	// The document to format.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The range to format
+	Range Range `json:"range,omitempty"`
+
+	// The format options
+	Options FormattingOptions `json:"options,omitempty"`
+}
+
+/**
+ * Provider options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest).
+ */
+type DocumentRangeFormattingOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Registration options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest).
+ */
+type DocumentRangeFormattingRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	DocumentRangeFormattingOptions
+}
+
+/**
+ * Client capabilities of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest).
+ */
+type DocumentOnTypeFormattingClientCapabilities struct {
+
+	// Whether on type formatting supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * The parameters of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest).
+ */
+type DocumentOnTypeFormattingParams struct {
+
+	// The document to format.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The position at which this request was send.
+	Position Position `json:"position,omitempty"`
+
+	// The character that has been typed.
+	Ch string `json:"ch,omitempty"`
+
+	// The format options.
+	Options FormattingOptions `json:"options,omitempty"`
+}
+
+/**
+ * Provider options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest).
+ */
+type DocumentOnTypeFormattingOptions struct {
+
+	// A character on which formatting should be triggered, like `}`.
+	FirstTriggerCharacter string `json:"firstTriggerCharacter,omitempty"`
+
+	// More trigger characters.
+	MoreTriggerCharacter *[]string `json:"moreTriggerCharacter,omitempty"`
+}
+
+/**
+ * Registration options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest).
+ */
+type DocumentOnTypeFormattingRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	DocumentOnTypeFormattingOptions
+}
+
+type RenameClientCapabilities struct {
+
+	// Whether rename supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// Client supports testing for validity of rename operations
+	// before execution.
+	//
+	// @since 3.12.0
+	PrepareSupport *bool `json:"prepareSupport,omitempty"`
+
+	// Client supports the default behavior result.
+	//
+	// The value indicates the default behavior used by the
+	// client.
+	//
+	// @since 3.16.0
+	PrepareSupportDefaultBehavior *PrepareSupportDefaultBehavior `json:"prepareSupportDefaultBehavior,omitempty"`
+
+	// Whether th client honors the change annotations in
+	// text edits and resource operations returned via the
+	// rename request's workspace edit by for example presenting
+	// the workspace edit in the user interface and asking
+	// for confirmation.
+	//
+	// @since 3.16.0
+	HonorsChangeAnnotations *bool `json:"honorsChangeAnnotations,omitempty"`
+}
+
+/**
+ * The parameters of a [RenameRequest](#RenameRequest).
+ */
+type RenameParams struct {
+	WorkDoneProgressParams
+
+	// The document to rename.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The position at which this request was sent.
+	Position Position `json:"position,omitempty"`
+
+	// The new name of the symbol. If the given name is not valid the
+	// request must return a [ResponseError](#ResponseError) with an
+	// appropriate message set.
+	NewName string `json:"newName,omitempty"`
+}
+
+/**
+ * Provider options for a [RenameRequest](#RenameRequest).
+ */
+type RenameOptions struct {
+	WorkDoneProgressOptions
+
+	// Renames should be checked and tested before being executed.
+	//
+	// @since version 3.12.0
+	PrepareProvider *bool `json:"prepareProvider,omitempty"`
+}
+
+/**
+ * Registration options for a [RenameRequest](#RenameRequest).
+ */
+type RenameRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	RenameOptions
+}
+
+type PrepareRenameParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+}
+
+/**
+ * The client capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest).
+ */
+type ExecuteCommandClientCapabilities struct {
+
+	// Execute command supports dynamic registration.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * The parameters of a [ExecuteCommandRequest](#ExecuteCommandRequest).
+ */
+type ExecuteCommandParams struct {
+	WorkDoneProgressParams
+
+	// The identifier of the actual command handler.
+	Command string `json:"command,omitempty"`
+
+	// Arguments that the command should be invoked with.
+	Arguments *[]interface{} `json:"arguments,omitempty"`
+}
+
+/**
+ * The server capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest).
+ */
+type ExecuteCommandOptions struct {
+	WorkDoneProgressOptions
+
+	// The commands to be executed on the server
+	Commands []string `json:"commands,omitempty"`
+}
+
+/**
+ * Registration options for a [ExecuteCommandRequest](#ExecuteCommandRequest).
+ */
+type ExecuteCommandRegistrationOptions struct {
+	ExecuteCommandOptions
+}
+
+// ---- Apply Edit request ----------------------------------------
+type WorkspaceEditClientCapabilities struct {
+
+	// The client supports versioned document changes in `WorkspaceEdit`s
+	DocumentChanges *bool `json:"documentChanges,omitempty"`
+
+	// The resource operations the client supports. Clients should at least
+	// support 'create', 'rename' and 'delete' files and folders.
+	//
+	// @since 3.13.0
+	ResourceOperations *[]ResourceOperationKind `json:"resourceOperations,omitempty"`
+
+	// The failure handling strategy of a client if applying the workspace edit
+	// fails.
+	//
+	// @since 3.13.0
+	FailureHandling *FailureHandlingKind `json:"failureHandling,omitempty"`
+
+	// Whether the client normalizes line endings to the client specific
+	// setting.
+	// If set to `true` the client will normalize line ending characters
+	// in a workspace edit containing to the client specific new line
+	// character.
+	//
+	// @since 3.16.0
+	NormalizesLineEndings *bool `json:"normalizesLineEndings,omitempty"`
+
+	// Whether the client in general supports change annotations on text edits,
+	// create file, rename file and delete file changes.
+	//
+	// @since 3.16.0
+	ChangeAnnotationSupport *struct {
+
+		// Whether the client groups edits with equal labels into tree nodes,
+		// for instance all edits labelled with "Changes in Strings" would
+		// be a tree node.
+		GroupsOnLabel *bool `json:"groupsOnLabel,omitempty"`
+	} `json:"changeAnnotationSupport,omitempty"`
+}
+
+/**
+ * The parameters passed via a apply workspace edit request.
+ */
+type ApplyWorkspaceEditParams struct {
+
+	// An optional label of the workspace edit. This label is
+	// presented in the user interface for example on an undo
+	// stack to undo the workspace edit.
+	Label *string `json:"label,omitempty"`
+
+	// The edits to apply.
+	Edit WorkspaceEdit `json:"edit,omitempty"`
+}
+
+/**
+ * The result returned from the apply workspace edit request.
+ *
+ * @since 3.17 renamed from ApplyWorkspaceEditResponse
+ */
+type ApplyWorkspaceEditResult struct {
+
+	// Indicates whether the edit was applied or not.
+	Applied bool `json:"applied,omitempty"`
+
+	// An optional textual description for why the edit was not applied.
+	// This may be used by the server for diagnostic logging or to provide
+	// a suitable error for a request that triggered the edit.
+	FailureReason *string `json:"failureReason,omitempty"`
+
+	// Depending on the client's failure handling strategy `failedChange` might
+	// contain the index of the change that failed. This property is only available
+	// if the client signals a `failureHandlingStrategy` in its client capabilities.
+	FailedChange *uint `json:"failedChange,omitempty"`
+}
+
+/**
+ * The `client/registerCapability` request is sent from the server to the client to register a new capability
+ * handler on the client side.
+ */
+type RegistrationRequest string
+
+const (
+	RegistrationRequestType RegistrationRequest = "new ProtocolRequestType<RegistrationParams, void, never, void, void>('client/registerCapability')"
+)
+
+/**
+ * The `client/unregisterCapability` request is sent from the server to the client to unregister a previously registered capability
+ * handler on the client side.
+ */
+type UnregistrationRequest string
+
+const (
+	UnregistrationRequestType UnregistrationRequest = "new ProtocolRequestType<UnregistrationParams, void, never, void, void>('client/unregisterCapability')"
+)
+
+type ResourceOperationKind string
+
+const (
+	/**
+	 * Supports creating new files and folders.
+	 */
+	ResourceOperationKindCreate ResourceOperationKind = "create"
+	/**
+	 * Supports renaming existing files and folders.
+	 */
+	ResourceOperationKindRename ResourceOperationKind = "rename"
+	/**
+	 * Supports deleting existing files and folders.
+	 */
+	ResourceOperationKindDelete ResourceOperationKind = "delete"
+)
+
+type FailureHandlingKind string
+
+const (
+	/**
+	 * Applying the workspace change is simply aborted if one of the changes provided
+	 * fails. All operations executed before the failing operation stay executed.
+	 */
+	FailureHandlingKindAbort FailureHandlingKind = "abort"
+	/**
+	 * All operations are executed transactional. That means they either all
+	 * succeed or no changes at all are applied to the workspace.
+	 */
+	FailureHandlingKindTransactional FailureHandlingKind = "transactional"
+	/**
+	 * If the workspace edit contains only textual file changes they are executed transactional.
+	 * If resource changes (create, rename or delete file) are part of the change the failure
+	 * handling strategy is abort.
+	 */
+	FailureHandlingKindTextOnlyTransactional FailureHandlingKind = "textOnlyTransactional"
+	/**
+	 * The client tries to undo the operations already executed. But there is no
+	 * guarantee that this is succeeding.
+	 */
+	FailureHandlingKindUndo FailureHandlingKind = "undo"
+)
+
+/**
+ * The initialize request is sent from the client to the server.
+ * It is sent once as the request after starting up the server.
+ * The requests parameter is of type [InitializeParams](#InitializeParams)
+ * the response if of type [InitializeResult](#InitializeResult) of a Thenable that
+ * resolves to such.
+ */
+type InitializeRequest string
+
+const (
+	InitializeRequestType InitializeRequest = "new ProtocolRequestType<InitializeParams & WorkDoneProgressParams, InitializeResult, never, InitializeError, void>('initialize')"
+)
+
+/**
+ * Known error codes for an `InitializeError`;
+ */
+type InitializeErrorCode int
+
+var initializeErrorStringMap = map[InitializeErrorCode]string{
+	InitializeErrorUnknownProtocolVersion: "unknownProtocolVersion",
+}
+
+func (i InitializeErrorCode) String() string {
+	if s, ok := initializeErrorStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * If the protocol version provided by the client can't be handled by the server.
+	 * @deprecated This initialize error got replaced by client capabilities. There is
+	 * no version handshake in version 3.0x
+	 */
+	InitializeErrorUnknownProtocolVersion InitializeErrorCode = 1
+)
+
+/**
+ * The initialized notification is sent from the client to the
+ * server after the client is fully initialized and the server
+ * is allowed to send requests from the server to the client.
+ */
+type InitializedNotification string
+
+const (
+	InitializedNotificationType InitializedNotification = "new ProtocolNotificationType<InitializedParams, void>('initialized')"
+)
+
+/**
+ * A shutdown request is sent from the client to the server.
+ * It is sent once when the client decides to shutdown the
+ * server. The only notification that is sent after a shutdown request
+ * is the exit event.
+ */
+type ShutdownRequest string
+
+const (
+	ShutdownRequestType ShutdownRequest = "new ProtocolRequestType0<void, never, void, void>('shutdown')"
+)
+
+/**
+ * The exit event is sent from the client to the server to
+ * ask the server to exit its process.
+ */
+type ExitNotification string
+
+const (
+	ExitNotificationType ExitNotification = "new ProtocolNotificationType0<void>('exit')"
+)
+
+/**
+ * The configuration change notification is sent from the client to the server
+ * when the client's configuration has changed. The notification contains
+ * the changed configuration as defined by the language client.
+ */
+type DidChangeConfigurationNotification string
+
+const (
+	DidChangeConfigurationNotificationType DidChangeConfigurationNotification = "new ProtocolNotificationType<DidChangeConfigurationParams, DidChangeConfigurationRegistrationOptions>('workspace/didChangeConfiguration')"
+)
+
+/**
+ * The message type
+ */
+type MessageType int
+
+var messageTypeStringMap = map[MessageType]string{
+	MessageTypeError:   "Error",
+	MessageTypeWarning: "Warning",
+	MessageTypeInfo:    "Info",
+	MessageTypeLog:     "Log",
+}
+
+func (i MessageType) String() string {
+	if s, ok := messageTypeStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * An error message.
+	 */
+	MessageTypeError MessageType = 1
+	/**
+	 * A warning message.
+	 */
+	MessageTypeWarning MessageType = 2
+	/**
+	 * An information message.
+	 */
+	MessageTypeInfo MessageType = 3
+	/**
+	 * A logs message.
+	 */
+	MessageTypeLog MessageType = 4
+)
+
+/**
+ * The show message notification is sent from a server to a client to ask
+ * the client to display a particular message in the user interface.
+ */
+type ShowMessageNotification string
+
+const (
+	ShowMessageNotificationType ShowMessageNotification = "new ProtocolNotificationType<ShowMessageParams, void>('window/showMessage')"
+)
+
+/**
+ * The show message request is sent from the server to the client to show a message
+ * and a set of options actions to the user.
+ */
+type ShowMessageRequest string
+
+const (
+	ShowMessageRequestType ShowMessageRequest = "new ProtocolRequestType<ShowMessageRequestParams, MessageActionItem | null, never, void, void>('window/showMessageRequest')"
+)
+
+/**
+ * The logs message notification is sent from the server to the client to ask
+ * the client to logs a particular message.
+ */
+type LogMessageNotification string
+
+const (
+	LogMessageNotificationType LogMessageNotification = "new ProtocolNotificationType<LogMessageParams, void>('window/logMessage')"
+)
+
+/**
+ * The telemetry event notification is sent from the server to the client to ask
+ * the client to logs telemetry data.
+ */
+type TelemetryEventNotification string
+
+const (
+	TelemetryEventNotificationType TelemetryEventNotification = "new ProtocolNotificationType<any, void>('telemetry/event')"
+)
+
+/**
+ * Defines how the host (editor) should sync
+ * document changes to the language server.
+ */
+type TextDocumentSyncKind int
+
+var textDocumentSyncKindStringMap = map[TextDocumentSyncKind]string{
+	TextDocumentSyncKindNone:        "None",
+	TextDocumentSyncKindFull:        "Full",
+	TextDocumentSyncKindIncremental: "Incremental",
+}
+
+func (i TextDocumentSyncKind) String() string {
+	if s, ok := textDocumentSyncKindStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * Documents should not be synced at all.
+	 */
+	TextDocumentSyncKindNone TextDocumentSyncKind = 0
+	/**
+	 * Documents are synced by always sending the full content
+	 * of the document.
+	 */
+	TextDocumentSyncKindFull TextDocumentSyncKind = 1
+	/**
+	 * Documents are synced by sending the full content on open.
+	 * After that only incremental updates to the document are
+	 * send.
+	 */
+	TextDocumentSyncKindIncremental TextDocumentSyncKind = 2
+)
+
+/**
+ * The document open notification is sent from the client to the server to signal
+ * newly opened text documents. The document's truth is now managed by the client
+ * and the server must not try to read the document's truth using the document's
+ * uri. Open in this sense means it is managed by the client. It doesn't necessarily
+ * mean that its content is presented in an editor. An open notification must not
+ * be sent more than once without a corresponding close notification send before.
+ * This means open and close notification must be balanced and the max open count
+ * is one.
+ */
+type DidOpenTextDocumentNotification string
+
+const (
+	DidOpenTextDocumentNotificationMethod DidOpenTextDocumentNotification = "textDocument/didOpen"
+
+	DidOpenTextDocumentNotificationType DidOpenTextDocumentNotification = "new ProtocolNotificationType<DidOpenTextDocumentParams, TextDocumentRegistrationOptions>(method)"
+)
+
+/**
+ * The document change notification is sent from the client to the server to signal
+ * changes to a text document.
+ */
+type DidChangeTextDocumentNotification string
+
+const (
+	DidChangeTextDocumentNotificationMethod DidChangeTextDocumentNotification = "textDocument/didChange"
+
+	DidChangeTextDocumentNotificationType DidChangeTextDocumentNotification = "new ProtocolNotificationType<DidChangeTextDocumentParams, TextDocumentChangeRegistrationOptions>(method)"
+)
+
+/**
+ * The document close notification is sent from the client to the server when
+ * the document got closed in the client. The document's truth now exists where
+ * the document's uri points to (e.g. if the document's uri is a file uri the
+ * truth now exists on disk). As with the open notification the close notification
+ * is about managing the document's content. Receiving a close notification
+ * doesn't mean that the document was open in an editor before. A close
+ * notification requires a previous open notification to be sent.
+ */
+type DidCloseTextDocumentNotification string
+
+const (
+	DidCloseTextDocumentNotificationMethod DidCloseTextDocumentNotification = "textDocument/didClose"
+
+	DidCloseTextDocumentNotificationType DidCloseTextDocumentNotification = "new ProtocolNotificationType<DidCloseTextDocumentParams, TextDocumentRegistrationOptions>(method)"
+)
+
+/**
+ * The document save notification is sent from the client to the server when
+ * the document got saved in the client.
+ */
+type DidSaveTextDocumentNotification string
+
+const (
+	DidSaveTextDocumentNotificationMethod DidSaveTextDocumentNotification = "textDocument/didSave"
+
+	DidSaveTextDocumentNotificationType DidSaveTextDocumentNotification = "new ProtocolNotificationType<DidSaveTextDocumentParams, TextDocumentSaveRegistrationOptions>(method)"
+)
+
+/**
+ * Represents reasons why a text document is saved.
+ */
+type TextDocumentSaveReason int
+
+var textDocumentSaveReasonStringMap = map[TextDocumentSaveReason]string{
+	TextDocumentSaveReasonManual:     "Manual",
+	TextDocumentSaveReasonAfterDelay: "AfterDelay",
+	TextDocumentSaveReasonFocusOut:   "FocusOut",
+}
+
+func (i TextDocumentSaveReason) String() string {
+	if s, ok := textDocumentSaveReasonStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * Manually triggered, e.g. by the user pressing save, by starting debugging,
+	 * or by an API call.
+	 */
+	TextDocumentSaveReasonManual TextDocumentSaveReason = 1
+	/**
+	 * Automatic after a delay.
+	 */
+	TextDocumentSaveReasonAfterDelay TextDocumentSaveReason = 2
+	/**
+	 * When the editor lost focus.
+	 */
+	TextDocumentSaveReasonFocusOut TextDocumentSaveReason = 3
+)
+
+/**
+ * A document will save notification is sent from the client to the server before
+ * the document is actually saved.
+ */
+type WillSaveTextDocumentNotification string
+
+const (
+	WillSaveTextDocumentNotificationMethod WillSaveTextDocumentNotification = "textDocument/willSave"
+
+	WillSaveTextDocumentNotificationType WillSaveTextDocumentNotification = "new ProtocolNotificationType<WillSaveTextDocumentParams, TextDocumentRegistrationOptions>(method)"
+)
+
+/**
+ * A document will save request is sent from the client to the server before
+ * the document is actually saved. The request can return an array of TextEdits
+ * which will be applied to the text document before it is saved. Please note that
+ * clients might drop results if computing the text edits took too long or if a
+ * server constantly fails on this request. This is done to keep the save fast and
+ * reliable.
+ */
+type WillSaveTextDocumentWaitUntilRequest string
+
+const (
+	WillSaveTextDocumentWaitUntilRequestMethod WillSaveTextDocumentWaitUntilRequest = "textDocument/willSaveWaitUntil"
+
+	WillSaveTextDocumentWaitUntilRequestType WillSaveTextDocumentWaitUntilRequest = "new ProtocolRequestType<WillSaveTextDocumentParams, TextEdit[] | null, never, void, TextDocumentRegistrationOptions>(method)"
+)
+
+/**
+ * The watched files notification is sent from the client to the server when
+ * the client detects changes to file watched by the language client.
+ */
+type DidChangeWatchedFilesNotification string
+
+const (
+	DidChangeWatchedFilesNotificationType DidChangeWatchedFilesNotification = "new ProtocolNotificationType<DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions>('workspace/didChangeWatchedFiles')"
+)
+
+/**
+ * The file event type
+ */
+type FileChangeType int
+
+var fileChangeTypeStringMap = map[FileChangeType]string{
+	FileChangeTypeCreated: "Created",
+	FileChangeTypeChanged: "Changed",
+	FileChangeTypeDeleted: "Deleted",
+}
+
+func (i FileChangeType) String() string {
+	if s, ok := fileChangeTypeStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * The file got created.
+	 */
+	FileChangeTypeCreated FileChangeType = 1
+	/**
+	 * The file got changed.
+	 */
+	FileChangeTypeChanged FileChangeType = 2
+	/**
+	 * The file got deleted.
+	 */
+	FileChangeTypeDeleted FileChangeType = 3
+)
+
+type WatchKind int
+
+var watchKindStringMap = map[WatchKind]string{
+	WatchKindCreate: "Create",
+	WatchKindChange: "Change",
+	WatchKindDelete: "Delete",
+}
+
+func (i WatchKind) String() string {
+	if s, ok := watchKindStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * Interested in create events.
+	 */
+	WatchKindCreate WatchKind = 1
+	/**
+	 * Interested in change events
+	 */
+	WatchKindChange WatchKind = 2
+	/**
+	 * Interested in delete events
+	 */
+	WatchKindDelete WatchKind = 4
+)
+
+/**
+ * Diagnostics notification are sent from the server to the client to signal
+ * results of validation runs.
+ */
+type PublishDiagnosticsNotification string
+
+const (
+	PublishDiagnosticsNotificationType PublishDiagnosticsNotification = "new ProtocolNotificationType<PublishDiagnosticsParams, void>('textDocument/publishDiagnostics')"
+)
+
+/**
+ * How a completion was triggered
+ */
+type CompletionTriggerKind int
+
+var completionTriggerKindStringMap = map[CompletionTriggerKind]string{
+	CompletionTriggerKindInvoked:                         "Invoked",
+	CompletionTriggerKindTriggerCharacter:                "TriggerCharacter",
+	CompletionTriggerKindTriggerForIncompleteCompletions: "TriggerForIncompleteCompletions",
+}
+
+func (i CompletionTriggerKind) String() string {
+	if s, ok := completionTriggerKindStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * Completion was triggered by typing an identifier (24x7 code
+	 * complete), manual invocation (e.g Ctrl+Space) or via API.
+	 */
+	CompletionTriggerKindInvoked CompletionTriggerKind = 1
+	/**
+	 * Completion was triggered by a trigger character specified by
+	 * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+	 */
+	CompletionTriggerKindTriggerCharacter CompletionTriggerKind = 2
+	/**
+	 * Completion was re-triggered as current completion list is incomplete
+	 */
+	CompletionTriggerKindTriggerForIncompleteCompletions CompletionTriggerKind = 3
+)
+
+/**
+ * Request to request completion at a given text document position. The request's
+ * parameter is of type [TextDocumentPosition](#TextDocumentPosition) the response
+ * is of type [CompletionItem[]](#CompletionItem) or [CompletionList](#CompletionList)
+ * or a Thenable that resolves to such.
+ *
+ * The request can delay the computation of the [`detail`](#CompletionItem.detail)
+ * and [`documentation`](#CompletionItem.documentation) properties to the `completionItem/resolve`
+ * request. However, properties that are needed for the initial sorting and filtering, like `sortText`,
+ * `filterText`, `insertText`, and `textEdit`, must not be changed during resolve.
+ */
+type CompletionRequest string
+
+const (
+	CompletionRequestMethod CompletionRequest = "textDocument/completion"
+
+	CompletionRequestType CompletionRequest = "new ProtocolRequestType<CompletionParams, CompletionItem[] | CompletionList | null, CompletionItem[], void, CompletionRegistrationOptions>(method)"
+)
+
+/**
+ * Request to resolve additional information for a given completion item.The request's
+ * parameter is of type [CompletionItem](#CompletionItem) the response
+ * is of type [CompletionItem](#CompletionItem) or a Thenable that resolves to such.
+ */
+type CompletionResolveRequest string
+
+const (
+	CompletionResolveRequestMethod CompletionResolveRequest = "completionItem/resolve"
+
+	CompletionResolveRequestType CompletionResolveRequest = "new ProtocolRequestType<CompletionItem, CompletionItem, never, void, void>(method)"
+)
+
+/**
+ * Request to request hover information at a given text document position. The request's
+ * parameter is of type [TextDocumentPosition](#TextDocumentPosition) the response is of
+ * type [Hover](#Hover) or a Thenable that resolves to such.
+ */
+type HoverRequest string
+
+const (
+	HoverRequestMethod HoverRequest = "textDocument/hover"
+
+	HoverRequestType HoverRequest = "new ProtocolRequestType<HoverParams, Hover | null, never, void, HoverRegistrationOptions>(method)"
+)
+
+/**
+ * How a signature help was triggered.
+ *
+ * @since 3.15.0
+ */
+type SignatureHelpTriggerKind int
+
+var signatureHelpTriggerKindStringMap = map[SignatureHelpTriggerKind]string{
+	SignatureHelpTriggerKindInvoked:          "Invoked",
+	SignatureHelpTriggerKindTriggerCharacter: "TriggerCharacter",
+	SignatureHelpTriggerKindContentChange:    "ContentChange",
+}
+
+func (i SignatureHelpTriggerKind) String() string {
+	if s, ok := signatureHelpTriggerKindStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * Signature help was invoked manually by the user or by a command.
+	 */
+	SignatureHelpTriggerKindInvoked SignatureHelpTriggerKind = 1
+	/**
+	 * Signature help was triggered by a trigger character.
+	 */
+	SignatureHelpTriggerKindTriggerCharacter SignatureHelpTriggerKind = 2
+	/**
+	 * Signature help was triggered by the cursor moving or by the document content changing.
+	 */
+	SignatureHelpTriggerKindContentChange SignatureHelpTriggerKind = 3
+)
+
+type SignatureHelpRequest string
+
+const (
+	SignatureHelpRequestMethod SignatureHelpRequest = "textDocument/signatureHelp"
+
+	SignatureHelpRequestType SignatureHelpRequest = "new ProtocolRequestType<SignatureHelpParams, SignatureHelp | null, never, void, SignatureHelpRegistrationOptions>(method)"
+)
+
+/**
+ * A request to resolve the definition location of a symbol at a given text
+ * document position. The request's parameter is of type [TextDocumentPosition]
+ * (#TextDocumentPosition) the response is of either type [Definition](#Definition)
+ * or a typed array of [DefinitionLink](#DefinitionLink) or a Thenable that resolves
+ * to such.
+ */
+type DefinitionRequest string
+
+const (
+	DefinitionRequestMethod DefinitionRequest = "textDocument/definition"
+
+	DefinitionRequestType DefinitionRequest = "new ProtocolRequestType<DefinitionParams, Definition | DefinitionLink[] | null, Location[] | DefinitionLink[], void, DefinitionRegistrationOptions>(method)"
+)
+
+/**
+ * A request to resolve project-wide references for the symbol denoted
+ * by the given text document position. The request's parameter is of
+ * type [ReferenceParams](#ReferenceParams) the response is of type
+ * [Location[]](#Location) or a Thenable that resolves to such.
+ */
+type ReferencesRequest string
+
+const (
+	ReferencesRequestMethod ReferencesRequest = "textDocument/references"
+
+	ReferencesRequestType ReferencesRequest = "new ProtocolRequestType<ReferenceParams, Location[] | null, Location[], void, ReferenceRegistrationOptions>(method)"
+)
+
+/**
+ * Request to resolve a [DocumentHighlight](#DocumentHighlight) for a given
+ * text document position. The request's parameter is of type [TextDocumentPosition]
+ * (#TextDocumentPosition) the request response is of type [DocumentHighlight[]]
+ * (#DocumentHighlight) or a Thenable that resolves to such.
+ */
+type DocumentHighlightRequest string
+
+const (
+	DocumentHighlightRequestMethod DocumentHighlightRequest = "textDocument/documentHighlight"
+
+	DocumentHighlightRequestType DocumentHighlightRequest = "new ProtocolRequestType<DocumentHighlightParams, DocumentHighlight[] | null, DocumentHighlight[], void, DocumentHighlightRegistrationOptions>(method)"
+)
+
+/**
+ * A request to list all symbols found in a given text document. The request's
+ * parameter is of type [TextDocumentIdentifier](#TextDocumentIdentifier) the
+ * response is of type [SymbolInformation[]](#SymbolInformation) or a Thenable
+ * that resolves to such.
+ */
+type DocumentSymbolRequest string
+
+const (
+	DocumentSymbolRequestMethod DocumentSymbolRequest = "textDocument/documentSymbol"
+
+	DocumentSymbolRequestType DocumentSymbolRequest = "new ProtocolRequestType<DocumentSymbolParams, SymbolInformation[] | DocumentSymbol[] | null, SymbolInformation[] | DocumentSymbol[], void, DocumentSymbolRegistrationOptions>(method)"
+)
+
+/**
+ * A request to provide commands for the given text document and range.
+ */
+type CodeActionRequest string
+
+const (
+	CodeActionRequestMethod CodeActionRequest = "textDocument/codeAction"
+
+	CodeActionRequestType CodeActionRequest = "new ProtocolRequestType<CodeActionParams, (Command | CodeAction)[] | null, (Command | CodeAction)[], void, CodeActionRegistrationOptions>(method)"
+)
+
+/**
+ * Request to resolve additional information for a given code action.The request's
+ * parameter is of type [CodeAction](#CodeAction) the response
+ * is of type [CodeAction](#CodeAction) or a Thenable that resolves to such.
+ */
+type CodeActionResolveRequest string
+
+const (
+	CodeActionResolveRequestMethod CodeActionResolveRequest = "codeAction/resolve"
+
+	CodeActionResolveRequestType CodeActionResolveRequest = "new ProtocolRequestType<CodeAction, CodeAction, never, void, void>(method)"
+)
+
+/**
+ * A request to list project-wide symbols matching the query string given
+ * by the [WorkspaceSymbolParams](#WorkspaceSymbolParams). The response is
+ * of type [SymbolInformation[]](#SymbolInformation) or a Thenable that
+ * resolves to such.
+ */
+type WorkspaceSymbolRequest string
+
+const (
+	WorkspaceSymbolRequestMethod WorkspaceSymbolRequest = "workspace/symbol"
+
+	WorkspaceSymbolRequestType WorkspaceSymbolRequest = "new ProtocolRequestType<WorkspaceSymbolParams, SymbolInformation[] | null, SymbolInformation[], void, WorkspaceSymbolRegistrationOptions>(method)"
+)
+
+/**
+ * A request to provide code lens for the given text document.
+ */
+type CodeLensRequest string
+
+const (
+	CodeLensRequestMethod CodeLensRequest = "textDocument/codeLens"
+
+	CodeLensRequestType CodeLensRequest = "new ProtocolRequestType<CodeLensParams, CodeLens[] | null, CodeLens[], void, CodeLensRegistrationOptions>(method)"
+)
+
+/**
+ * A request to resolve a command for a given code lens.
+ */
+type CodeLensResolveRequest string
+
+const (
+	CodeLensResolveRequestMethod CodeLensResolveRequest = "codeLens/resolve"
+
+	CodeLensResolveRequestType CodeLensResolveRequest = "new ProtocolRequestType<CodeLens, CodeLens, never, void, void>(method)"
+)
+
+/**
+ * A request to refresh all code actions
+ *
+ * @since 3.16.0
+ */
+type CodeLensRefreshRequest string
+
+const (
+	CodeLensRefreshRequestMethod CodeLensRefreshRequest = "`workspace/codeLens/refresh`"
+
+	CodeLensRefreshRequestType CodeLensRefreshRequest = "new ProtocolRequestType0<void, void, void, void>(method)"
+)
+
+/**
+ * A request to provide document links
+ */
+type DocumentLinkRequest string
+
+const (
+	DocumentLinkRequestMethod DocumentLinkRequest = "textDocument/documentLink"
+
+	DocumentLinkRequestType DocumentLinkRequest = "new ProtocolRequestType<DocumentLinkParams, DocumentLink[] | null, DocumentLink[], void, DocumentLinkRegistrationOptions>(method)"
+)
+
+/**
+ * Request to resolve additional information for a given document link. The request's
+ * parameter is of type [DocumentLink](#DocumentLink) the response
+ * is of type [DocumentLink](#DocumentLink) or a Thenable that resolves to such.
+ */
+type DocumentLinkResolveRequest string
+
+const (
+	DocumentLinkResolveRequestMethod DocumentLinkResolveRequest = "documentLink/resolve"
+
+	DocumentLinkResolveRequestType DocumentLinkResolveRequest = "new ProtocolRequestType<DocumentLink, DocumentLink, never, void, void>(method)"
+)
+
+/**
+ * A request to to format a whole document.
+ */
+type DocumentFormattingRequest string
+
+const (
+	DocumentFormattingRequestMethod DocumentFormattingRequest = "textDocument/formatting"
+
+	DocumentFormattingRequestType DocumentFormattingRequest = "new ProtocolRequestType<DocumentFormattingParams, TextEdit[] | null, never, void, DocumentFormattingRegistrationOptions>(method)"
+)
+
+/**
+ * A request to to format a range in a document.
+ */
+type DocumentRangeFormattingRequest string
+
+const (
+	DocumentRangeFormattingRequestMethod DocumentRangeFormattingRequest = "textDocument/rangeFormatting"
+
+	DocumentRangeFormattingRequestType DocumentRangeFormattingRequest = "new ProtocolRequestType<DocumentRangeFormattingParams, TextEdit[] | null, never, void, DocumentRangeFormattingRegistrationOptions>(method)"
+)
+
+/**
+ * A request to format a document on type.
+ */
+type DocumentOnTypeFormattingRequest string
+
+const (
+	DocumentOnTypeFormattingRequestMethod DocumentOnTypeFormattingRequest = "textDocument/onTypeFormatting"
+
+	DocumentOnTypeFormattingRequestType DocumentOnTypeFormattingRequest = "new ProtocolRequestType<DocumentOnTypeFormattingParams, TextEdit[] | null, never, void, DocumentOnTypeFormattingRegistrationOptions>(method)"
+)
+
+// ---- Rename ----------------------------------------------
+type PrepareSupportDefaultBehavior int
+
+var prepareSupportDefaultBehaviorStringMap = map[PrepareSupportDefaultBehavior]string{
+	PrepareSupportDefaultBehaviorIdentifier: "Identifier",
+}
+
+func (i PrepareSupportDefaultBehavior) String() string {
+	if s, ok := prepareSupportDefaultBehaviorStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * The client's default behavior is to select the identifier
+	 * according the to language's syntax rule.
+	 */
+	PrepareSupportDefaultBehaviorIdentifier PrepareSupportDefaultBehavior = 1
+)
+
+/**
+ * A request to rename a symbol.
+ */
+type RenameRequest string
+
+const (
+	RenameRequestMethod RenameRequest = "textDocument/rename"
+
+	RenameRequestType RenameRequest = "new ProtocolRequestType<RenameParams, WorkspaceEdit | null, never, void, RenameRegistrationOptions>(method)"
+)
+
+/**
+ * A request to test and perform the setup necessary for a rename.
+ *
+ * @since 3.16 - support for default behavior
+ */
+type PrepareRenameRequest string
+
+const (
+	PrepareRenameRequestMethod PrepareRenameRequest = "textDocument/prepareRename"
+
+	PrepareRenameRequestType PrepareRenameRequest = "new ProtocolRequestType<PrepareRenameParams, Range | { range: Range, placeholder: string } | { defaultBehavior: boolean } | null, never, void, void>(method)"
+)
+
+/**
+ * A request send from the client to the server to execute a command. The request might return
+ * a workspace edit which the client will apply to the workspace.
+ */
+type ExecuteCommandRequest string
+
+const (
+	ExecuteCommandRequestType ExecuteCommandRequest = "new ProtocolRequestType<ExecuteCommandParams, any | null, never, void, ExecuteCommandRegistrationOptions>('workspace/executeCommand')"
+)
+
+/**
+ * A request sent from the server to the client to modified certain resources.
+ */
+type ApplyWorkspaceEditRequest string
+
+const (
+	ApplyWorkspaceEditRequestType ApplyWorkspaceEditRequest = "new ProtocolRequestType<ApplyWorkspaceEditParams, ApplyWorkspaceEditResult, never, void, void>('workspace/applyEdit')"
+)

--- a/misc/regopls/lsp/defines/protocol.implementation.go
+++ b/misc/regopls/lsp/defines/protocol.implementation.go
@@ -1,0 +1,33 @@
+package defines
+
+/**
+ * @since 3.6.0
+ */
+type ImplementationClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration. If this is set to `true`
+	// the client supports the new `ImplementationRegistrationOptions` return value
+	// for the corresponding server capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The client supports additional metadata in the form of definition links.
+	//
+	// @since 3.14.0
+	LinkSupport *bool `json:"linkSupport,omitempty"`
+}
+
+type ImplementationOptions struct {
+	WorkDoneProgressOptions
+}
+
+type ImplementationRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	ImplementationOptions
+	StaticRegistrationOptions
+}
+
+type ImplementationParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+	PartialResultParams
+}

--- a/misc/regopls/lsp/defines/protocol.inlineValue.go
+++ b/misc/regopls/lsp/defines/protocol.inlineValue.go
@@ -1,0 +1,68 @@
+package defines
+
+/**
+ * Client capabilities specific to inline values.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration for inline value providers.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * Client workspace capabilities specific to inline values.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesWorkspaceClientCapabilities struct {
+
+	// Whether the client implementation supports a refresh request sent from the
+	// server to the client.
+	//
+	// Note that this event is global and will force the client to refresh all
+	// inline values currently shown. It should be used with absolute care and is
+	// useful for situation where a server for example detect a project wide
+	// change that requires such a calculation.
+	RefreshSupport *bool `json:"refreshSupport,omitempty"`
+}
+
+/**
+ * Inline values options used during static registration.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Inline value options used during static or dynamic registration.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesRegistrationOptions struct {
+	InlineValuesOptions
+	TextDocumentRegistrationOptions
+	StaticRegistrationOptions
+}
+
+/**
+ * A parameter literal used in inline values requests.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesParams struct {
+	WorkDoneProgressParams
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The visible document range for which inline values should be computed.
+	ViewPort Range `json:"viewPort,omitempty"`
+
+	// Additional information about the context in which inline values were
+	// requested.
+	Context InlineValuesContext `json:"context,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.linkedEditingRange.go
+++ b/misc/regopls/lsp/defines/protocol.linkedEditingRange.go
@@ -1,0 +1,46 @@
+package defines
+
+/**
+ * Client capabilities for the linked editing range request.
+ *
+ * @since 3.16.0
+ */
+type LinkedEditingRangeClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration. If this is set to `true`
+	// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+	// return value for the corresponding server capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+type LinkedEditingRangeParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+}
+
+type LinkedEditingRangeOptions struct {
+	WorkDoneProgressOptions
+}
+
+type LinkedEditingRangeRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	LinkedEditingRangeOptions
+	StaticRegistrationOptions
+}
+
+/**
+ * The result of a linked editing range request.
+ *
+ * @since 3.16.0
+ */
+type LinkedEditingRanges struct {
+
+	// A list of ranges that can be edited together. The ranges must have
+	// identical length and contain identical text content. The ranges cannot overlap.
+	Ranges []Range `json:"ranges,omitempty"`
+
+	// An optional word pattern (regular expression) that describes valid contents for
+	// the given ranges. If no pattern is provided, the client configuration's word
+	// pattern will be used.
+	WordPattern *string `json:"wordPattern,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.moniker.go
+++ b/misc/regopls/lsp/defines/protocol.moniker.go
@@ -1,0 +1,116 @@
+package defines
+
+/**
+ * Moniker definition to match LSIF 0.5 moniker definition.
+ *
+ * @since 3.16.0
+ */
+type Moniker struct {
+
+	// The scheme of the moniker. For example tsc or .Net
+	Scheme string `json:"scheme,omitempty"`
+
+	// The identifier of the moniker. The value is opaque in LSIF however
+	// schema owners are allowed to define the structure if they want.
+	Identifier string `json:"identifier,omitempty"`
+
+	// The scope in which the moniker is unique
+	Unique UniquenessLevel `json:"unique,omitempty"`
+
+	// The moniker kind if known.
+	Kind *MonikerKind `json:"kind,omitempty"`
+}
+
+/**
+ * Client capabilities specific to the moniker request.
+ *
+ * @since 3.16.0
+ */
+type MonikerClientCapabilities struct {
+
+	// Whether moniker supports dynamic registration. If this is set to `true`
+	// the client supports the new `MonikerRegistrationOptions` return value
+	// for the corresponding server capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+type MonikerOptions struct {
+	WorkDoneProgressOptions
+}
+
+type MonikerRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	MonikerOptions
+}
+
+type MonikerParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+	PartialResultParams
+}
+
+/**
+ * Moniker uniqueness level to define scope of the moniker.
+ *
+ * @since 3.16.0
+ */
+type UniquenessLevel string
+
+const (
+	/**
+	 * The moniker is only unique inside a document
+	 */
+	UniquenessLevelDocument UniquenessLevel = "document"
+	/**
+	 * The moniker is unique inside a project for which a dump got created
+	 */
+	UniquenessLevelProject UniquenessLevel = "project"
+	/**
+	 * The moniker is unique inside the group to which a project belongs
+	 */
+	UniquenessLevelGroup UniquenessLevel = "group"
+	/**
+	 * The moniker is unique inside the moniker scheme.
+	 */
+	UniquenessLevelScheme UniquenessLevel = "scheme"
+	/**
+	 * The moniker is globally unique
+	 */
+	UniquenessLevelGlobal UniquenessLevel = "global"
+)
+
+/**
+ * The moniker kind.
+ *
+ * @since 3.16.0
+ */
+type MonikerKind string
+
+const (
+	/**
+	 * The moniker represent a symbol that is imported into a project
+	 */
+	MonikerKindImport MonikerKind = "import"
+	/**
+	 * The moniker represents a symbol that is exported from a project
+	 */
+	MonikerKindExport MonikerKind = "export"
+	/**
+	 * The moniker represents a symbol that is local to a project (e.g. a local
+	 * variable of a function, a class not visible outside the project, ...)
+	 */
+	MonikerKindLocal MonikerKind = "local"
+)
+
+/**
+ * A request to get the moniker of a symbol at a given text document position.
+ * The request parameter is of type [TextDocumentPositionParams](#TextDocumentPositionParams).
+ * The response is of type [Moniker[]](#Moniker[]) or `null`.
+ */
+type MonikerRequest string
+
+const (
+	MonikerRequestMethod MonikerRequest = "textDocument/moniker"
+
+	MonikerRequestType MonikerRequest = "new ProtocolRequestType<MonikerParams, Moniker[] | null, Moniker[], void, MonikerRegistrationOptions>(method)"
+)

--- a/misc/regopls/lsp/defines/protocol.progress.go
+++ b/misc/regopls/lsp/defines/protocol.progress.go
@@ -1,0 +1,89 @@
+package defines
+
+type WorkDoneProgressClientCapabilities struct {
+
+	// Window specific client capabilities.
+	Window *struct {
+
+		// Whether client supports server initiated progress using the
+		// `windowworkDoneProgresscreate` request.
+		//
+		// Since 3.15.0
+		WorkDoneProgress *bool `json:"workDoneProgress,omitempty"`
+	} `json:"window,omitempty"`
+}
+
+type WorkDoneProgressBegin struct {
+	Kind interface{} `json:"kind,omitempty"` // 'begin'
+
+	// Mandatory title of the progress operation. Used to briefly inform about
+	// the kind of operation being performed.
+	//
+	// Examples: "Indexing" or "Linking dependencies".
+	Title string `json:"title,omitempty"`
+
+	// Controls if a cancel button should show to allow the user to cancel the
+	// long running operation. Clients that don't support cancellation are allowed
+	// to ignore the setting.
+	Cancellable *bool `json:"cancellable,omitempty"`
+
+	// Optional, more detailed associated progress message. Contains
+	// complementary information to the `title`.
+	//
+	// Examples: "325 files", "projectsrcmodule2", "node_modulessome_dep".
+	// If unset, the previous progress message (if any) is still valid.
+	Message *string `json:"message,omitempty"`
+
+	// Optional progress percentage to display (value 100 is considered 100%).
+	// If not provided infinite progress is assumed and clients are allowed
+	// to ignore the `percentage` value in subsequent in report notifications.
+	//
+	// The value should be steadily rising. Clients are free to ignore values
+	// that are not following this rule. The value range is [0, 100].
+	Percentage *uint `json:"percentage,omitempty"`
+}
+
+type WorkDoneProgressReport struct {
+	Kind interface{} `json:"kind,omitempty"` // 'report'
+
+	// Controls enablement state of a cancel button.
+	//
+	// Clients that don't support cancellation or don't support controlling the button's
+	// enablement state are allowed to ignore the property.
+	Cancellable *bool `json:"cancellable,omitempty"`
+
+	// Optional, more detailed associated progress message. Contains
+	// complementary information to the `title`.
+	//
+	// Examples: "325 files", "projectsrcmodule2", "node_modulessome_dep".
+	// If unset, the previous progress message (if any) is still valid.
+	Message *string `json:"message,omitempty"`
+
+	// Optional progress percentage to display (value 100 is considered 100%).
+	// If not provided infinite progress is assumed and clients are allowed
+	// to ignore the `percentage` value in subsequent in report notifications.
+	//
+	// The value should be steadily rising. Clients are free to ignore values
+	// that are not following this rule. The value range is [0, 100]
+	Percentage *uint `json:"percentage,omitempty"`
+}
+
+type WorkDoneProgressEnd struct {
+	Kind interface{} `json:"kind,omitempty"` // 'end'
+
+	// Optional, a final message indicating to for example indicate the outcome
+	// of the operation.
+	Message *string `json:"message,omitempty"`
+}
+
+type WorkDoneProgressCreateParams struct {
+
+	// The token to be used to report progress.
+	Token ProgressToken `json:"token,omitempty"`
+}
+
+type WorkDoneProgressCancelParams struct {
+
+	// The token to be used to report progress.
+	Token ProgressToken `json:"token,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.selectionRange.go
+++ b/misc/regopls/lsp/defines/protocol.selectionRange.go
@@ -1,0 +1,34 @@
+package defines
+
+// ---- capabilities
+type SelectionRangeClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration for selection range providers. If this is set to `true`
+	// the client supports the new `SelectionRangeRegistrationOptions` return value for the corresponding server
+	// capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+type SelectionRangeOptions struct {
+	WorkDoneProgressOptions
+}
+
+type SelectionRangeRegistrationOptions struct {
+	SelectionRangeOptions
+	TextDocumentRegistrationOptions
+	StaticRegistrationOptions
+}
+
+/**
+ * A parameter literal used in selection range requests.
+ */
+type SelectionRangeParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The positions inside the text document.
+	Positions []Position `json:"positions,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.semanticTokens.go
+++ b/misc/regopls/lsp/defines/protocol.semanticTokens.go
@@ -1,0 +1,155 @@
+package defines
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensPartialResult struct {
+	Data []uint `json:"data,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensDeltaPartialResult struct {
+	Edits []SemanticTokensEdit `json:"edits,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration. If this is set to `true`
+	// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+	// return value for the corresponding server capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// Which requests the client supports and might send to the server
+	// depending on the server's capability. Please note that clients might not
+	// show semantic tokens or degrade some of the user experience if a range
+	// or full request is advertised by the client but not provided by the
+	// server. If for example the client capability `requests.full` and
+	// `request.range` are both set to true but the server only provides a
+	// range provider the client might not render a minimap correctly or might
+	// even decide to not show any semantic tokens at all.
+	Requests interface{} `json:"requests,omitempty"` // range, full,
+
+	// The token types that the client supports.
+	TokenTypes []string `json:"tokenTypes,omitempty"`
+
+	// The token modifiers that the client supports.
+	TokenModifiers []string `json:"tokenModifiers,omitempty"`
+
+	// The token formats the clients supports.
+	Formats []TokenFormat `json:"formats,omitempty"`
+
+	// Whether the client supports tokens that can overlap each other.
+	OverlappingTokenSupport *bool `json:"overlappingTokenSupport,omitempty"`
+
+	// Whether the client supports tokens that can span multiple lines.
+	MultilineTokenSupport *bool `json:"multilineTokenSupport,omitempty"`
+
+	// Whether the client allows the server to actively cancel a
+	// semantic token request, e.g. supports returning
+	// LSPErrorCodes.ServerCancelled. If a server does the client
+	// needs to retrigger the request.
+	//
+	// @since 3.17.0
+	ServerCancelSupport *bool `json:"serverCancelSupport,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensOptions struct {
+	WorkDoneProgressOptions
+
+	// The legend used by the server
+	Legend SemanticTokensLegend `json:"legend,omitempty"`
+
+	// Server supports providing semantic tokens for a specific range
+	// of a document.
+	Range *bool `json:"range,omitempty"`
+
+	// Server supports providing semantic tokens for a full document.
+	Full *bool `json:"full,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	SemanticTokensOptions
+	StaticRegistrationOptions
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensDeltaParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The result id of a previous response. The result Id can either point to a full response
+	// or a delta response depending on what was received last.
+	PreviousResultId string `json:"previousResultId,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensRangeParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	// The text document.
+	TextDocument TextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	// The range the semantic tokens are requested for.
+	Range Range `json:"range,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensWorkspaceClientCapabilities struct {
+
+	// Whether the client implementation supports a refresh request sent from
+	// the server to the client.
+	//
+	// Note that this event is global and will force the client to refresh all
+	// semantic tokens currently shown. It should be used with absolute care
+	// and is useful for situation where a server for example detects a project
+	// wide change that requires such a calculation.
+	RefreshSupport *bool `json:"refreshSupport,omitempty"`
+}
+
+// ------- 'textDocument/semanticTokens' -----
+type TokenFormat string
+
+const (
+	TokenFormatRelative TokenFormat = "relative"
+)
+
+type SemanticTokensRegistrationType string
+
+const (
+	SemanticTokensRegistrationTypeMethod SemanticTokensRegistrationType = "textDocument/semanticTokens"
+
+	SemanticTokensRegistrationTypeType SemanticTokensRegistrationType = "new RegistrationType<SemanticTokensRegistrationOptions>(method)"
+)

--- a/misc/regopls/lsp/defines/protocol.showDocument.go
+++ b/misc/regopls/lsp/defines/protocol.showDocument.go
@@ -1,0 +1,52 @@
+package defines
+
+/**
+ * Client capabilities for the show document request.
+ *
+ * @since 3.16.0
+ */
+type ShowDocumentClientCapabilities struct {
+
+	// The client has support for the show document
+	// request.
+	Support bool `json:"support,omitempty"`
+}
+
+/**
+ * Params to show a document.
+ *
+ * @since 3.16.0
+ */
+type ShowDocumentParams struct {
+
+	// The document uri to show.
+	Uri URI `json:"uri,omitempty"`
+
+	// Indicates to show the resource in an external program.
+	// To show for example `https:code.visualstudio.com`
+	// in the default WEB browser set `external` to `true`.
+	External *bool `json:"external,omitempty"`
+
+	// An optional property to indicate whether the editor
+	// showing the document should take focus or not.
+	// Clients might ignore this property if an external
+	// program in started.
+	TakeFocus *bool `json:"takeFocus,omitempty"`
+
+	// An optional selection range if the document is a text
+	// document. Clients might ignore the property if an
+	// external program is started or the file is not a text
+	// file.
+	Selection *Range `json:"selection,omitempty"`
+}
+
+/**
+ * The result of an show document request.
+ *
+ * @since 3.16.0
+ */
+type ShowDocumentResult struct {
+
+	// A boolean indicating if the show was successful.
+	Success bool `json:"success,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.typeDefinition.go
+++ b/misc/regopls/lsp/defines/protocol.typeDefinition.go
@@ -1,0 +1,33 @@
+package defines
+
+/**
+ * Since 3.6.0
+ */
+type TypeDefinitionClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration. If this is set to `true`
+	// the client supports the new `TypeDefinitionRegistrationOptions` return value
+	// for the corresponding server capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+
+	// The client supports additional metadata in the form of definition links.
+	//
+	// Since 3.14.0
+	LinkSupport *bool `json:"linkSupport,omitempty"`
+}
+
+type TypeDefinitionOptions struct {
+	WorkDoneProgressOptions
+}
+
+type TypeDefinitionRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	TypeDefinitionOptions
+	StaticRegistrationOptions
+}
+
+type TypeDefinitionParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+	PartialResultParams
+}

--- a/misc/regopls/lsp/defines/protocol.typeHierarchy.go
+++ b/misc/regopls/lsp/defines/protocol.typeHierarchy.go
@@ -1,0 +1,66 @@
+package defines
+
+/**
+ * @since 3.17.0 - proposed state
+ */
+type TypeHierarchyClientCapabilities struct {
+
+	// Whether implementation supports dynamic registration. If this is set to `true`
+	// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+	// return value for the corresponding server capability as well.
+	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * Type hierarchy options used during static registration.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type TypeHierarchyOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * Type hierarchy options used during static or dynamic registration.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type TypeHierarchyRegistrationOptions struct {
+	TextDocumentRegistrationOptions
+	TypeHierarchyOptions
+	StaticRegistrationOptions
+}
+
+/**
+ * The parameter of a `textDocument/prepareTypeHierarchy` request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type TypeHierarchyPrepareParams struct {
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+}
+
+/**
+ * The parameter of a `typeHierarchy/supertypes` request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type TypeHierarchySupertypesParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	Item TypeHierarchyItem `json:"item,omitempty"`
+}
+
+/**
+ * The parameter of a `typeHierarchy/subtypes` request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type TypeHierarchySubtypesParams struct {
+	WorkDoneProgressParams
+	PartialResultParams
+
+	Item TypeHierarchyItem `json:"item,omitempty"`
+}

--- a/misc/regopls/lsp/defines/protocol.workspaceFolders.go
+++ b/misc/regopls/lsp/defines/protocol.workspaceFolders.go
@@ -1,0 +1,58 @@
+package defines
+
+type WorkspaceFoldersInitializeParams struct {
+
+	// The actual configured workspace folders.
+	WorkspaceFolders interface{} `json:"workspaceFolders,omitempty"` // []WorkspaceFolder, null,
+}
+
+type WorkspaceFoldersClientCapabilities struct {
+
+	// The workspace client capabilities
+	Workspace *struct {
+
+		// The client has support for workspace folders
+		//
+		// @since 3.6.0
+		WorkspaceFolders *bool `json:"workspaceFolders,omitempty"`
+	} `json:"workspace,omitempty"`
+}
+
+type WorkspaceFoldersServerCapabilities struct {
+
+	// The workspace server capabilities
+	Workspace *struct {
+		WorkspaceFolders interface{} `json:"workspaceFolders,omitempty"` // supported, changeNotifications,
+	} `json:"workspace,omitempty"`
+}
+
+type WorkspaceFolder struct {
+
+	// The associated URI for this workspace folder.
+	Uri string `json:"uri,omitempty"`
+
+	// The name of the workspace folder. Used to refer to this
+	// workspace folder in the user interface.
+	Name string `json:"name,omitempty"`
+}
+
+/**
+ * The parameters of a `workspace/didChangeWorkspaceFolders` notification.
+ */
+type DidChangeWorkspaceFoldersParams struct {
+
+	// The actual workspace folder change event.
+	Event WorkspaceFoldersChangeEvent `json:"event,omitempty"`
+}
+
+/**
+ * The workspace folder change event.
+ */
+type WorkspaceFoldersChangeEvent struct {
+
+	// The array of added workspace folders
+	Added []WorkspaceFolder `json:"added,omitempty"`
+
+	// The array of the removed workspace folders
+	Removed []WorkspaceFolder `json:"removed,omitempty"`
+}

--- a/misc/regopls/lsp/defines/types.go
+++ b/misc/regopls/lsp/defines/types.go
@@ -1,0 +1,2046 @@
+package defines
+
+/**
+ * A tagging type for string properties that are actually document URIs.
+ */
+type DocumentUri string
+
+/**
+ * A tagging type for string properties that are actually URIs
+ *
+ * @since 3.16.0
+ */
+type URI string
+
+/**
+ * An identifier to refer to a change annotation stored with a workspace edit.
+ */
+type ChangeAnnotationIdentifier string
+
+/**
+ * Information about where a symbol is defined.
+ *
+ * Provides additional metadata over normal [location](#Location) definitions, including the range of
+ * the defining symbol
+ */
+type DefinitionLink LocationLink
+
+/**
+ * Information about where a symbol is declared.
+ *
+ * Provides additional metadata over normal [location](#Location) declarations, including the range of
+ * the declaring symbol.
+ *
+ * Servers should prefer returning `DeclarationLink` over `Declaration` if supported
+ * by the client.
+ */
+type DeclarationLink LocationLink
+
+/**
+ * The kind of a code action.
+ *
+ * Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactor.extract.function"`.
+ *
+ * The set of kinds is open and client needs to announce the kinds it supports to the server during
+ * initialization.
+ */
+
+/**
+ * Position in a text document expressed as zero-based line and character offset.
+ * The offsets are based on a UTF-16 string representation. So a string of the form
+ * `a𐐀b` the character offset of the character `a` is 0, the character offset of `𐐀`
+ * is 1 and the character offset of b is 3 since `𐐀` is represented using two code
+ * units in UTF-16.
+ *
+ * Positions are line end character agnostic. So you can not specify a position that
+ * denotes `\r|\n` or `\n|` where `|` represents the character offset.
+ */
+type Position struct {
+
+	// Line position in a document (zero-based).
+	Line uint `json:"line"`
+
+	// Character offset on a line in a document (zero-based). Assuming that the line is
+	// represented as a string, the `character` value represents the gap between the
+	// `character` and `character + 1`.
+	//
+	// If the character value is greater than the line length it defaults back to the
+	// line length.
+	Character uint `json:"character"`
+}
+
+/**
+ * A range in a text document expressed as (zero-based) start and end positions.
+ *
+ * If you want to specify a range that contains a line including the line ending
+ * character(s) then use an end position denoting the start of the next line.
+ * For example:
+ * ```ts
+ * {
+ *     start: { line: 5, character: 23 }
+ *     end : { line 6, character : 0 }
+ * }
+ * ```
+ */
+type Range struct {
+
+	// The range's start position
+	Start Position `json:"start,omitempty"`
+
+	// The range's end position.
+	End Position `json:"end,omitempty"`
+}
+
+/**
+ * Represents a location inside a resource, such as a line
+ * inside a text file.
+ */
+type Location struct {
+	Uri DocumentUri `json:"uri,omitempty"`
+
+	Range Range `json:"range,omitempty"`
+}
+
+/**
+ * Represents the connection of two locations. Provides additional metadata over normal [locations](#Location),
+ * including an origin range.
+ */
+type LocationLink struct {
+
+	// Span of the origin of this link.
+	//
+	// Used as the underlined span for mouse definition hover. Defaults to the word range at
+	// the definition position.
+	OriginSelectionRange *Range `json:"originSelectionRange,omitempty"`
+
+	// The target resource identifier of this link.
+	TargetUri DocumentUri `json:"targetUri,omitempty"`
+
+	// The full target range of this link. If the target for example is a symbol then target range is the
+	// range enclosing this symbol not including leadingtrailing whitespace but everything else
+	// like comments. This information is typically used to highlight the range in the editor.
+	TargetRange Range `json:"targetRange,omitempty"`
+
+	// The range that should be selected and revealed when this link is being followed, e.g the name of a function.
+	// Must be contained by the the `targetRange`. See also `DocumentSymbol#range`
+	TargetSelectionRange Range `json:"targetSelectionRange,omitempty"`
+}
+
+/**
+ * Represents a color in RGBA space.
+ */
+type Color struct {
+
+	// The red component of this color in the range [0-1].
+	Red float32 `json:"red,omitempty"`
+
+	// The green component of this color in the range [0-1].
+	Green float32 `json:"green,omitempty"`
+
+	// The blue component of this color in the range [0-1].
+	Blue float32 `json:"blue,omitempty"`
+
+	// The alpha component of this color in the range [0-1].
+	Alpha float32 `json:"alpha,omitempty"`
+}
+
+/**
+ * Represents a color range from a document.
+ */
+type ColorInformation struct {
+
+	// The range in the document where this color appears.
+	Range Range `json:"range,omitempty"`
+
+	// The actual color value for this color range.
+	Color Color `json:"color,omitempty"`
+}
+
+type ColorPresentation struct {
+
+	// The label of this color presentation. It will be shown on the color
+	// picker header. By default this is also the text that is inserted when selecting
+	// this color presentation.
+	Label string `json:"label,omitempty"`
+
+	// An [edit](#TextEdit) which is applied to a document when selecting
+	// this presentation for the color.  When `falsy` the [label](#ColorPresentation.label)
+	// is used.
+	TextEdit *TextEdit `json:"textEdit,omitempty"`
+
+	// An optional array of additional [text edits](#TextEdit) that are applied when
+	// selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves.
+	AdditionalTextEdits *[]TextEdit `json:"additionalTextEdits,omitempty"`
+}
+
+/**
+ * Represents a folding range. To be valid, start and end line must be bigger than zero and smaller
+ * than the number of lines in the document. Clients are free to ignore invalid ranges.
+ */
+type FoldingRange struct {
+
+	// The zero-based start line of the range to fold. The folded area starts after the line's last character.
+	// To be valid, the end must be zero or larger and smaller than the number of lines in the document.
+	StartLine uint `json:"startLine,omitempty"`
+
+	// The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
+	StartCharacter *uint `json:"startCharacter,omitempty"`
+
+	// The zero-based end line of the range to fold. The folded area ends with the line's last character.
+	// To be valid, the end must be zero or larger and smaller than the number of lines in the document.
+	EndLine uint `json:"endLine,omitempty"`
+
+	// The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
+	EndCharacter *uint `json:"endCharacter,omitempty"`
+
+	// Describes the kind of the folding range such as `comment' or 'region'. The kind
+	// is used to categorize folding ranges and used by commands like 'Fold all comments'. See
+	// [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
+	Kind *string `json:"kind,omitempty"`
+}
+
+/**
+ * Represents a related message and source code location for a diagnostic. This should be
+ * used to point to code locations that cause or related to a diagnostics, e.g when duplicating
+ * a symbol in a scope.
+ */
+type DiagnosticRelatedInformation struct {
+
+	// The location of this related diagnostic information.
+	Location Location `json:"location,omitempty"`
+
+	// The message of this related diagnostic information.
+	Message string `json:"message,omitempty"`
+}
+
+/**
+ * Structure to capture a description for an error code.
+ *
+ * @since 3.16.0
+ */
+type CodeDescription struct {
+
+	// An URI to open with more information about the diagnostic error.
+	Href URI `json:"href,omitempty"`
+}
+
+/**
+ * Represents a diagnostic, such as a compiler error or warning. Diagnostic objects
+ * are only valid in the scope of a resource.
+ */
+type Diagnostic struct {
+
+	// The range at which the message applies
+	Range Range `json:"range,omitempty"`
+
+	// The diagnostic's severity. Can be omitted. If omitted it is up to the
+	// client to interpret diagnostics as error, warning, info or hint.
+	Severity *DiagnosticSeverity `json:"severity,omitempty"`
+
+	// The diagnostic's code, which usually appear in the user interface.
+	Code interface{} `json:"code,omitempty"` // int, string,
+
+	// An optional property to describe the error code.
+	// Requires the code field (above) to be presentnot null.
+	//
+	// @since 3.16.0
+	CodeDescription *CodeDescription `json:"codeDescription,omitempty"`
+
+	// A human-readable string describing the source of this
+	// diagnostic, e.g. 'typescript' or 'super lint'. It usually
+	// appears in the user interface.
+	Source *string `json:"source,omitempty"`
+
+	// The diagnostic's message. It usually appears in the user interface
+	Message string `json:"message,omitempty"`
+
+	// Additional metadata about the diagnostic.
+	//
+	// @since 3.15.0
+	Tags *[]DiagnosticTag `json:"tags,omitempty"`
+
+	// An array of related diagnostic information, e.g. when symbol-names within
+	// a scope collide all definitions can be marked via this property.
+	RelatedInformation *[]DiagnosticRelatedInformation `json:"relatedInformation,omitempty"`
+
+	// A data entry field that is preserved between a `textDocumentpublishDiagnostics`
+	// notification and `textDocumentcodeAction` request.
+	//
+	// @since 3.16.0
+	Data interface{} `json:"data,omitempty"`
+}
+
+/**
+ * Represents a reference to a command. Provides a title which
+ * will be used to represent a command in the UI and, optionally,
+ * an array of arguments which will be passed to the command handler
+ * function when invoked.
+ */
+type Command struct {
+
+	// Title of the command, like `save`.
+	Title string `json:"title,omitempty"`
+
+	// The identifier of the actual command handler.
+	Command string `json:"command,omitempty"`
+
+	// Arguments that the command handler should be
+	// invoked with.
+	Arguments *[]interface{} `json:"arguments,omitempty"`
+}
+
+/**
+ * A text edit applicable to a text document.
+ */
+type TextEdit struct {
+
+	// The range of the text document to be manipulated. To insert
+	// text into a document create a range where start === end.
+	Range Range `json:"range,omitempty"`
+
+	// The string to be inserted. For delete operations use an
+	// empty string.
+	NewText string `json:"newText,omitempty"`
+}
+
+/**
+ * Additional information that describes document changes.
+ *
+ * @since 3.16.0
+ */
+type ChangeAnnotation struct {
+
+	// A human-readable string describing the actual change. The string
+	// is rendered prominent in the user interface.
+	Label string `json:"label,omitempty"`
+
+	// A flag which indicates that user confirmation is needed
+	// before applying the change.
+	NeedsConfirmation *bool `json:"needsConfirmation,omitempty"`
+
+	// A human-readable string which is rendered less prominent in
+	// the user interface.
+	Description *string `json:"description,omitempty"`
+}
+
+/**
+ * A special text edit with an additional change annotation.
+ *
+ * @since 3.16.0.
+ */
+type AnnotatedTextEdit struct {
+	TextEdit
+
+	// The actual identifier of the change annotation
+	AnnotationId ChangeAnnotationIdentifier `json:"annotationId,omitempty"`
+}
+
+/**
+ * A generic resource operation.
+ */
+type ResourceOperation struct {
+
+	// The resource operation kind.
+	Kind string `json:"kind,omitempty"`
+
+	// An optional annotation identifier describing the operation.
+	//
+	// @since 3.16.0
+	AnnotationId *ChangeAnnotationIdentifier `json:"annotationId,omitempty"`
+}
+
+/**
+ * Options to create a file.
+ */
+type CreateFileOptions struct {
+
+	// Overwrite existing file. Overwrite wins over `ignoreIfExists`
+	Overwrite *bool `json:"overwrite,omitempty"`
+
+	// Ignore if exists.
+	IgnoreIfExists *bool `json:"ignoreIfExists,omitempty"`
+}
+
+/**
+ * Create file operation.
+ */
+type CreateFile struct {
+	ResourceOperation
+
+	// A create
+	Kind interface{} `json:"kind,omitempty"` // 'create'
+
+	// The resource to create.
+	Uri DocumentUri `json:"uri,omitempty"`
+
+	// Additional options
+	Options *CreateFileOptions `json:"options,omitempty"`
+}
+
+/**
+ * Rename file options
+ */
+type RenameFileOptions struct {
+
+	// Overwrite target if existing. Overwrite wins over `ignoreIfExists`
+	Overwrite *bool `json:"overwrite,omitempty"`
+
+	// Ignores if target exists.
+	IgnoreIfExists *bool `json:"ignoreIfExists,omitempty"`
+}
+
+/**
+ * Rename file operation
+ */
+type RenameFile struct {
+	ResourceOperation
+
+	// A rename
+	Kind interface{} `json:"kind,omitempty"` // 'rename'
+
+	// The old (existing) location.
+	OldUri DocumentUri `json:"oldUri,omitempty"`
+
+	// The new location.
+	NewUri DocumentUri `json:"newUri,omitempty"`
+
+	// Rename options.
+	Options *RenameFileOptions `json:"options,omitempty"`
+}
+
+/**
+ * Delete file options
+ */
+type DeleteFileOptions struct {
+
+	// Delete the content recursively if a folder is denoted.
+	Recursive *bool `json:"recursive,omitempty"`
+
+	// Ignore the operation if the file doesn't exist.
+	IgnoreIfNotExists *bool `json:"ignoreIfNotExists,omitempty"`
+}
+
+/**
+ * Delete file operation
+ */
+type DeleteFile struct {
+	ResourceOperation
+
+	// A delete
+	Kind interface{} `json:"kind,omitempty"` // 'delete'
+
+	// The file to delete.
+	Uri DocumentUri `json:"uri,omitempty"`
+
+	// Delete options.
+	Options *DeleteFileOptions `json:"options,omitempty"`
+}
+
+/**
+ * A literal to identify a text document in the client.
+ */
+type TextDocumentIdentifier struct {
+
+	// The text document's uri.
+	Uri DocumentUri `json:"uri,omitempty"`
+}
+
+/**
+ * A text document identifier to denote a specific version of a text document.
+ */
+type VersionedTextDocumentIdentifier struct {
+	TextDocumentIdentifier
+
+	// The version number of this document.
+	Version int `json:"version,omitempty"`
+}
+
+/**
+ * A text document identifier to optionally denote a specific version of a text document.
+ */
+type OptionalVersionedTextDocumentIdentifier struct {
+	TextDocumentIdentifier
+
+	// The version number of this document. If a versioned text document identifier
+	// is sent from the server to the client and the file is not open in the editor
+	// (the server has not received an open notification before) the server can send
+	// `null` to indicate that the version is unknown and the content on disk is the
+	// truth (as specified with document content ownership).
+	Version interface{} `json:"version,omitempty"` // int, null,
+}
+
+/**
+ * An item to transfer a text document from the client to the
+ * server.
+ */
+type TextDocumentItem struct {
+
+	// The text document's uri.
+	Uri DocumentUri `json:"uri,omitempty"`
+
+	// The text document's language identifier
+	LanguageId string `json:"languageId,omitempty"`
+
+	// The version number of this document (it will increase after each
+	// change, including undoredo).
+	Version int `json:"version,omitempty"`
+
+	// The content of the opened text document.
+	Text string `json:"text,omitempty"`
+}
+
+/**
+ * A `MarkupContent` literal represents a string value which content is interpreted base on its
+ * kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
+ *
+ * If the kind is `markdown` then the value can contain fenced code blocks like in GitHub issues.
+ * See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+ *
+ * Here is an example how such a string can be constructed using JavaScript / TypeScript:
+ * ```ts
+ * let markdown: MarkdownContent = {
+ *  kind: MarkupKind.Markdown,
+ *	value: [
+ *		'# Header',
+ *		'Some text',
+ *		'```typescript',
+ *		'someCode();',
+ *		'```'
+ *	].join('\n')
+ * };
+ * ```
+ *
+ * *Please Note* that clients might sanitize the return markdown. A client could decide to
+ * remove HTML from the markdown to avoid script execution.
+ */
+type MarkupContent struct {
+
+	// The type of the Markup
+	Kind MarkupKind `json:"kind,omitempty"`
+
+	// The content itself
+	Value string `json:"value,omitempty"`
+}
+
+/**
+ * A special text edit to provide an insert and a replace operation.
+ *
+ * @since 3.16.0
+ */
+type InsertReplaceEdit struct {
+
+	// The string to be inserted.
+	NewText string `json:"newText,omitempty"`
+
+	// The range if the insert is requested
+	Insert Range `json:"insert,omitempty"`
+
+	// The range if the replace is requested.
+	Replace Range `json:"replace,omitempty"`
+}
+
+/**
+ * Additional details for a completion item label.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type CompletionItemLabelDetails struct {
+
+	// An optional string which is rendered less prominently directly after {@link CompletionItem.label label},
+	// without any spacing. Should be used for function signatures or type annotations.
+	Detail *string `json:"detail,omitempty"`
+
+	// An optional string which is rendered less prominently after {@link CompletionItem.detail}. Should be used
+	// for fully qualified names or file path.
+	Description *string `json:"description,omitempty"`
+}
+
+/**
+ * A completion item represents a text snippet that is
+ * proposed to complete text that is being typed.
+ */
+type CompletionItem struct {
+
+	// The label of this completion item.
+	//
+	// The label property is also by default the text that
+	// is inserted when selecting this completion.
+	//
+	// If label details are provided the label itself should
+	// be an unqualified name of the completion item.
+	Label string `json:"label,omitempty"`
+
+	// Additional details for the label
+	//
+	// @since 3.17.0 - proposed state
+	LabelDetails *CompletionItemLabelDetails `json:"labelDetails,omitempty"`
+
+	// The kind of this completion item. Based of the kind
+	// an icon is chosen by the editor.
+	Kind *CompletionItemKind `json:"kind,omitempty"`
+
+	// Tags for this completion item.
+	//
+	// @since 3.15.0
+	Tags *[]CompletionItemTag `json:"tags,omitempty"`
+
+	// A human-readable string with additional information
+	// about this item, like type or symbol information.
+	Detail *string `json:"detail,omitempty"`
+
+	// A human-readable string that represents a doc-comment.
+	Documentation interface{} `json:"documentation,omitempty"` // string, MarkupContent,
+
+	// Indicates if this item is deprecated.
+	// @deprecated Use `tags` instead.
+	Deprecated *bool `json:"deprecated,omitempty"`
+
+	// Select this item when showing.
+	//
+	// Note that only one completion item can be selected and that the
+	// tool  client decides which item that is. The rule is that the first
+	// item of those that match best is selected.
+	Preselect *bool `json:"preselect,omitempty"`
+
+	// A string that should be used when comparing this item
+	// with other items. When `falsy` the [label](#CompletionItem.label)
+	// is used.
+	SortText *string `json:"sortText,omitempty"`
+
+	// A string that should be used when filtering a set of
+	// completion items. When `falsy` the [label](#CompletionItem.label)
+	// is used.
+	FilterText *string `json:"filterText,omitempty"`
+
+	// A string that should be inserted into a document when selecting
+	// this completion. When `falsy` the [label](#CompletionItem.label)
+	// is used.
+	//
+	// The `insertText` is subject to interpretation by the client side.
+	// Some tools might not take the string literally. For example
+	// VS Code when code complete is requested in this example `con<cursor position>`
+	// and a completion item with an `insertText` of `console` is provided it
+	// will only insert `sole`. Therefore it is recommended to use `textEdit` instead
+	// since it avoids additional client side interpretation.
+	InsertText *string `json:"insertText,omitempty"`
+
+	// The format of the insert text. The format applies to both the `insertText` property
+	// and the `newText` property of a provided `textEdit`. If omitted defaults to
+	// `InsertTextFormat.PlainText`.
+	//
+	// Please note that the insertTextFormat doesn't apply to `additionalTextEdits`.
+	InsertTextFormat *InsertTextFormat `json:"insertTextFormat,omitempty"`
+
+	// How whitespace and indentation is handled during completion
+	// item insertion. If ignored the clients default value depends on
+	// the `textDocument.completion.insertTextMode` client capability.
+	//
+	// @since 3.16.0
+	InsertTextMode *InsertTextMode `json:"insertTextMode,omitempty"`
+
+	// An [edit](#TextEdit) which is applied to a document when selecting
+	// this completion. When an edit is provided the value of
+	// [insertText](#CompletionItem.insertText) is ignored.
+	//
+	// Most editors support two different operation when accepting a completion item. One is to insert a
+	// completion text and the other is to replace an existing text with a completion text. Since this can
+	// usually not predetermined by a server it can report both ranges. Clients need to signal support for
+	// `InsertReplaceEdits` via the `textDocument.completion.insertReplaceSupport` client capability
+	// property.
+	//
+	// Note 1: The text edit's range as well as both ranges from a insert replace edit must be a
+	// [single line] and they must contain the position at which completion has been requested.
+	// Note 2: If an `InsertReplaceEdit` is returned the edit's insert range must be a prefix of
+	// the edit's replace range, that means it must be contained and starting at the same position.
+	//
+	// @since 3.16.0 additional type `InsertReplaceEdit`
+	TextEdit interface{} `json:"textEdit,omitempty"` // TextEdit, InsertReplaceEdit,
+
+	// An optional array of additional [text edits](#TextEdit) that are applied when
+	// selecting this completion. Edits must not overlap (including the same insert position)
+	// with the main [edit](#CompletionItem.textEdit) nor with themselves.
+	//
+	// Additional text edits should be used to change text unrelated to the current cursor position
+	// (for example adding an import statement at the top of the file if the completion item will
+	// insert an unqualified type).
+	AdditionalTextEdits *[]TextEdit `json:"additionalTextEdits,omitempty"`
+
+	// An optional set of characters that when pressed while this completion is active will accept it first and
+	// then type that character. Note that all commit characters should have `length=1` and that superfluous
+	// characters will be ignored.
+	CommitCharacters *[]string `json:"commitCharacters,omitempty"`
+
+	// An optional [command](#Command) that is executed after inserting this completion. Note that
+	// additional modifications to the current document should be described with the
+	// [additionalTextEdits](#CompletionItem.additionalTextEdits)-property.
+	Command *Command `json:"command,omitempty"`
+
+	// A data entry field that is preserved on a completion item between a
+	// [CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest](#CompletionResolveRequest).
+	Data interface{} `json:"data,omitempty"`
+}
+
+/**
+ * Represents a collection of [completion items](#CompletionItem) to be presented
+ * in the editor.
+ */
+type CompletionList struct {
+
+	// This list it not complete. Further typing results in recomputing this list.
+	IsIncomplete bool `json:"isIncomplete,omitempty"`
+
+	// The completion items.
+	Items []CompletionItem `json:"items,omitempty"`
+}
+
+/**
+ * The result of a hover request.
+ */
+type Hover struct {
+
+	// The hover's content
+	Contents interface{} `json:"contents,omitempty"` // MarkupContent, MarkedString, []MarkedString,
+
+	// An optional range
+	Range *Range `json:"range,omitempty"`
+}
+
+/**
+ * Represents the signature of something callable. A signature
+ * can have a label, like a function-name, a doc-comment, and
+ * a set of parameters.
+ */
+type SignatureInformation struct {
+
+	// The label of this signature. Will be shown in
+	// the UI.
+	Label string `json:"label,omitempty"`
+
+	// The human-readable doc-comment of this signature. Will be shown
+	// in the UI but can be omitted.
+	Documentation interface{} `json:"documentation,omitempty"` // string, MarkupContent,
+
+	// The parameters of this signature.
+	Parameters *[]ParameterInformation `json:"parameters,omitempty"`
+
+	// The index of the active parameter.
+	//
+	// If provided, this is used in place of `SignatureHelp.activeParameter`.
+	//
+	// @since 3.16.0
+	ActiveParameter *uint `json:"activeParameter,omitempty"`
+}
+
+/**
+ * Signature help represents the signature of something
+ * callable. There can be multiple signature but only one
+ * active and only one active parameter.
+ */
+type SignatureHelp struct {
+
+	// One or more signatures.
+	Signatures []SignatureInformation `json:"signatures,omitempty"`
+
+	// The active signature. If omitted or the value lies outside the
+	// range of `signatures` the value defaults to zero or is ignored if
+	// the `SignatureHelp` has no signatures.
+	//
+	// Whenever possible implementors should make an active decision about
+	// the active signature and shouldn't rely on a default value.
+	//
+	// In future version of the protocol this property might become
+	// mandatory to better express this.
+	ActiveSignature *uint `json:"activeSignature,omitempty"`
+
+	// The active parameter of the active signature. If omitted or the value
+	// lies outside the range of `signatures[activeSignature].parameters`
+	// defaults to 0 if the active signature has parameters. If
+	// the active signature has no parameters it is ignored.
+	// In future version of the protocol this property might become
+	// mandatory to better express the active parameter if the
+	// active signature does have any.
+	ActiveParameter *uint `json:"activeParameter,omitempty"`
+}
+
+/**
+ * Value-object that contains additional information when
+ * requesting references.
+ */
+type ReferenceContext struct {
+
+	// Include the declaration of the current symbol.
+	IncludeDeclaration bool `json:"includeDeclaration,omitempty"`
+}
+
+/**
+ * A document highlight is a range inside a text document which deserves
+ * special attention. Usually a document highlight is visualized by changing
+ * the background color of its range.
+ */
+type DocumentHighlight struct {
+
+	// The range this highlight applies to.
+	Range Range `json:"range,omitempty"`
+
+	// The highlight kind, default is [text](#DocumentHighlightKind.Text).
+	Kind *DocumentHighlightKind `json:"kind,omitempty"`
+}
+
+/**
+ * Represents information about programming constructs like variables, classes,
+ * interfaces etc.
+ */
+type SymbolInformation struct {
+
+	// The name of this symbol.
+	Name string `json:"name,omitempty"`
+
+	// The kind of this symbol.
+	Kind SymbolKind `json:"kind,omitempty"`
+
+	// Tags for this completion item.
+	//
+	// @since 3.16.0
+	Tags *[]SymbolTag `json:"tags,omitempty"`
+
+	// Indicates if this symbol is deprecated.
+	//
+	// @deprecated Use tags instead
+	Deprecated *bool `json:"deprecated,omitempty"`
+
+	// The location of this symbol. The location's range is used by a tool
+	// to reveal the location in the editor. If the symbol is selected in the
+	// tool the range's start information is used to position the cursor. So
+	// the range usually spans more than the actual symbol's name and does
+	// normally include thinks like visibility modifiers.
+	//
+	// The range doesn't have to denote a node range in the sense of a abstract
+	// syntax tree. It can therefore not be used to re-construct a hierarchy of
+	// the symbols.
+	Location Location `json:"location,omitempty"`
+
+	// The name of the symbol containing this symbol. This information is for
+	// user interface purposes (e.g. to render a qualifier in the user interface
+	// if necessary). It can't be used to re-infer a hierarchy for the document
+	// symbols.
+	ContainerName *string `json:"containerName,omitempty"`
+}
+
+/**
+ * Represents programming constructs like variables, classes, interfaces etc.
+ * that appear in a document. Document symbols can be hierarchical and they
+ * have two ranges: one that encloses its definition and one that points to
+ * its most interesting range, e.g. the range of an identifier.
+ */
+type DocumentSymbol struct {
+
+	// The name of this symbol. Will be displayed in the user interface and therefore must not be
+	// an empty string or a string only consisting of white spaces.
+	Name string `json:"name,omitempty"`
+
+	// More detail for this symbol, e.g the signature of a function.
+	Detail *string `json:"detail,omitempty"`
+
+	// The kind of this symbol.
+	Kind SymbolKind `json:"kind,omitempty"`
+
+	// Tags for this document symbol.
+	//
+	// @since 3.16.0
+	Tags *[]SymbolTag `json:"tags,omitempty"`
+
+	// Indicates if this symbol is deprecated.
+	//
+	// @deprecated Use tags instead
+	Deprecated *bool `json:"deprecated,omitempty"`
+
+	// The range enclosing this symbol not including leadingtrailing whitespace but everything else
+	// like comments. This information is typically used to determine if the the clients cursor is
+	// inside the symbol to reveal in the symbol in the UI.
+	Range Range `json:"range,omitempty"`
+
+	// The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+	// Must be contained by the the `range`.
+	SelectionRange Range `json:"selectionRange,omitempty"`
+
+	// Children of this symbol, e.g. properties of a class.
+	Children *[]DocumentSymbol `json:"children,omitempty"`
+}
+
+/**
+ * Contains additional diagnostic information about the context in which
+ * a [code action](#CodeActionProvider.provideCodeActions) is run.
+ */
+type CodeActionContext struct {
+
+	// An array of diagnostics known on the client side overlapping the range provided to the
+	// `textDocumentcodeAction` request. They are provided so that the server knows which
+	// errors are currently presented to the user for the given range. There is no guarantee
+	// that these accurately reflect the error state of the resource. The primary parameter
+	// to compute code actions is the provided range.
+	Diagnostics []Diagnostic `json:"diagnostics,omitempty"`
+
+	// Requested kind of actions to return.
+	//
+	// Actions not of this kind are filtered out by the client before being shown. So servers
+	// can omit computing them.
+	Only *[]CodeActionKind `json:"only,omitempty"`
+}
+
+/**
+ * A code action represents a change that can be performed in code, e.g. to fix a problem or
+ * to refactor code.
+ *
+ * A CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed.
+ */
+type CodeAction struct {
+
+	// A short, human-readable, title for this code action.
+	Title string `json:"title,omitempty"`
+
+	// The kind of the code action.
+	//
+	// Used to filter code actions.
+	Kind *CodeActionKind `json:"kind,omitempty"`
+
+	// The diagnostics that this code action resolves.
+	Diagnostics *[]Diagnostic `json:"diagnostics,omitempty"`
+
+	// Marks this as a preferred action. Preferred actions are used by the `auto fix` command and can be targeted
+	// by keybindings.
+	//
+	// A quick fix should be marked preferred if it properly addresses the underlying error.
+	// A refactoring should be marked preferred if it is the most reasonable choice of actions to take.
+	//
+	// @since 3.15.0
+	IsPreferred *bool `json:"isPreferred,omitempty"`
+
+	// Marks that the code action cannot currently be applied.
+	//
+	// Clients should follow the following guidelines regarding disabled code actions:
+	//
+	// - Disabled code actions are not shown in automatic [lightbulb](https:code.visualstudio.comdocseditoreditingevolved#_code-action)
+	// code action menu.
+	//
+	// - Disabled actions are shown as faded out in the code action menu when the user request a more specific type
+	// of code action, such as refactorings.
+	//
+	// - If the user has a [keybinding](https:code.visualstudio.comdocseditorrefactoring#_keybindings-for-code-actions)
+	// that auto applies a code action and only a disabled code actions are returned, the client should show the user an
+	// error message with `reason` in the editor.
+	//
+	// @since 3.16.0
+	Disabled *struct {
+
+		// Human readable description of why the code action is currently disabled.
+		//
+		// This is displayed in the code actions UI.
+		Reason string `json:"reason,omitempty"`
+	} `json:"disabled,omitempty"`
+
+	// The workspace edit this code action performs.
+	Edit *WorkspaceEdit `json:"edit,omitempty"`
+
+	// A command this code action executes. If a code action
+	// provides a edit and a command, first the edit is
+	// executed and then the command.
+	Command *Command `json:"command,omitempty"`
+
+	// A data entry field that is preserved on a code action between
+	// a `textDocumentcodeAction` and a `codeActionresolve` request.
+	//
+	// @since 3.16.0
+	Data interface{} `json:"data,omitempty"`
+}
+
+/**
+ * A code lens represents a [command](#Command) that should be shown along with
+ * source text, like the number of references, a way to run tests, etc.
+ *
+ * A code lens is _unresolved_ when no command is associated to it. For performance
+ * reasons the creation of a code lens and resolving should be done to two stages.
+ */
+type CodeLens struct {
+
+	// The range in which this code lens is valid. Should only span a single line.
+	Range Range `json:"range,omitempty"`
+
+	// The command this code lens represents.
+	Command *Command `json:"command,omitempty"`
+
+	// A data entry field that is preserved on a code lens item between
+	// a [CodeLensRequest](#CodeLensRequest) and a [CodeLensResolveRequest]
+	// (#CodeLensResolveRequest)
+	Data interface{} `json:"data,omitempty"`
+}
+
+/**
+ * Value-object describing what options formatting should use.
+ */
+type FormattingOptions struct {
+
+	// Size of a tab in spaces.
+	TabSize uint `json:"tabSize,omitempty"`
+
+	// Prefer spaces over tabs.
+	InsertSpaces bool `json:"insertSpaces,omitempty"`
+
+	// Trim trailing whitespaces on a line.
+	//
+	// @since 3.15.0
+	TrimTrailingWhitespace *bool `json:"trimTrailingWhitespace,omitempty"`
+
+	// Insert a newline character at the end of the file if one does not exist.
+	//
+	// @since 3.15.0
+	InsertFinalNewline *bool `json:"insertFinalNewline,omitempty"`
+
+	// Trim all newlines after the final newline at the end of the file.
+	//
+	// @since 3.15.0
+	TrimFinalNewlines *bool `json:"trimFinalNewlines,omitempty"`
+
+	// Signature for further properties.
+	Key interface{} `json:"key,omitempty"` // bool, int, string, undefined,
+}
+
+/**
+ * A document link is a range in a text document that links to an internal or external resource, like another
+ * text document or a web site.
+ */
+type DocumentLink struct {
+
+	// The range this link applies to.
+	Range Range `json:"range,omitempty"`
+
+	// The uri this link points to.
+	Target *string `json:"target,omitempty"`
+
+	// The tooltip text when you hover over this link.
+	//
+	// If a tooltip is provided, is will be displayed in a string that includes instructions on how to
+	// trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary depending on OS,
+	// user settings, and localization.
+	//
+	// @since 3.15.0
+	Tooltip *string `json:"tooltip,omitempty"`
+
+	// A data entry field that is preserved on a document link between a
+	// DocumentLinkRequest and a DocumentLinkResolveRequest.
+	Data interface{} `json:"data,omitempty"`
+}
+
+/**
+ * A selection range represents a part of a selection hierarchy. A selection range
+ * may have a parent selection range that contains it.
+ */
+type SelectionRange struct {
+
+	// The [range](#Range) of this selection range.
+	Range Range `json:"range,omitempty"`
+
+	// The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
+	Parent *SelectionRange `json:"parent,omitempty"`
+}
+
+/**
+ * Represents programming constructs like functions or constructors in the context
+ * of call hierarchy.
+ *
+ * @since 3.16.0
+ */
+type CallHierarchyItem struct {
+
+	// The name of this item.
+	Name string `json:"name,omitempty"`
+
+	// The kind of this item.
+	Kind SymbolKind `json:"kind,omitempty"`
+
+	// Tags for this item.
+	Tags *[]SymbolTag `json:"tags,omitempty"`
+
+	// More detail for this item, e.g. the signature of a function.
+	Detail *string `json:"detail,omitempty"`
+
+	// The resource identifier of this item.
+	Uri DocumentUri `json:"uri,omitempty"`
+
+	// The range enclosing this symbol not including leadingtrailing whitespace but everything else, e.g. comments and code.
+	Range Range `json:"range,omitempty"`
+
+	// The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.
+	// Must be contained by the [`range`](#CallHierarchyItem.range).
+	SelectionRange Range `json:"selectionRange,omitempty"`
+
+	// A data entry field that is preserved between a call hierarchy prepare and
+	// incoming calls or outgoing calls requests.
+	Data interface{} `json:"data,omitempty"`
+}
+
+/**
+ * Represents an incoming call, e.g. a caller of a method or constructor.
+ *
+ * @since 3.16.0
+ */
+type CallHierarchyIncomingCall struct {
+
+	// The item that makes the call.
+	From CallHierarchyItem `json:"from,omitempty"`
+
+	// The ranges at which the calls appear. This is relative to the caller
+	// denoted by [`this.from`](#CallHierarchyIncomingCall.from).
+	FromRanges []Range `json:"fromRanges,omitempty"`
+}
+
+/**
+ * Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
+ *
+ * @since 3.16.0
+ */
+type CallHierarchyOutgoingCall struct {
+
+	// The item that is called.
+	To CallHierarchyItem `json:"to,omitempty"`
+
+	// The range at which this item is called. This is the range relative to the caller, e.g the item
+	// passed to [`provideCallHierarchyOutgoingCalls`](#CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls)
+	// and not [`this.to`](#CallHierarchyOutgoingCall.to).
+	FromRanges []Range `json:"fromRanges,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensLegend struct {
+
+	// The token types a server uses.
+	TokenTypes []string `json:"tokenTypes,omitempty"`
+
+	// The token modifiers a server uses.
+	TokenModifiers []string `json:"tokenModifiers,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokens struct {
+
+	// An optional result id. If provided and clients support delta updating
+	// the client will include the result id in the next semantic token request.
+	// A server can then instead of computing all semantic tokens again simply
+	// send a delta.
+	ResultId *string `json:"resultId,omitempty"`
+
+	// The actual tokens.
+	Data []uint `json:"data,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensEdit struct {
+
+	// The start offset of the edit.
+	Start uint `json:"start,omitempty"`
+
+	// The count of elements to remove.
+	DeleteCount uint `json:"deleteCount,omitempty"`
+
+	// The elements to insert.
+	Data *[]uint `json:"data,omitempty"`
+}
+
+/**
+ * @since 3.16.0
+ */
+type SemanticTokensDelta struct {
+	ResultId *string `json:"resultId,omitempty"`
+
+	// The semantic token edits to transform a previous result into a new result.
+	Edits []SemanticTokensEdit `json:"edits,omitempty"`
+}
+
+/**
+ * @since 3.17.0 - proposed state
+ */
+type TypeHierarchyItem struct {
+
+	// The name of this item.
+	Name string `json:"name,omitempty"`
+
+	// The kind of this item.
+	Kind SymbolKind `json:"kind,omitempty"`
+
+	// Tags for this item.
+	Tags *[]SymbolTag `json:"tags,omitempty"`
+
+	// More detail for this item, e.g. the signature of a function.
+	Detail *string `json:"detail,omitempty"`
+
+	// The resource identifier of this item.
+	Uri DocumentUri `json:"uri,omitempty"`
+
+	// The range enclosing this symbol not including leadingtrailing whitespace
+	// but everything else, e.g. comments and code.
+	Range Range `json:"range,omitempty"`
+
+	// The range that should be selected and revealed when this symbol is being
+	// picked, e.g. the name of a function. Must be contained by the
+	// [`range`](#TypeHierarchyItem.range).
+	SelectionRange Range `json:"selectionRange,omitempty"`
+
+	// A data entry field that is preserved between a type hierarchy prepare and
+	// supertypes or subtypes requests. It could also be used to identify the
+	// type hierarchy in the server, helping improve the performance on
+	// resolving supertypes and subtypes.
+	Data interface{} `json:"data,omitempty"`
+}
+
+/**
+ * Provide inline value as text.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValueText struct {
+
+	// The document range for which the inline value applies.
+	Range Range `json:"range,omitempty"`
+
+	// The text of the inline value.
+	Text string `json:"text,omitempty"`
+}
+
+/**
+ * Provide inline value through a variable lookup.
+ * If only a range is specified, the variable name will be extracted from the underlying document.
+ * An optional variable name can be used to override the extracted name.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValueVariableLookup struct {
+
+	// The document range for which the inline value applies.
+	// The range is used to extract the variable name from the underlying document.
+	Range Range `json:"range,omitempty"`
+
+	// If specified the name of the variable to look up.
+	VariableName *string `json:"variableName,omitempty"`
+
+	// How to perform the lookup.
+	CaseSensitiveLookup bool `json:"caseSensitiveLookup,omitempty"`
+}
+
+/**
+ * Provide an inline value through an expression evaluation.
+ * If only a range is specified, the expression will be extracted from the underlying document.
+ * An optional expression can be used to override the extracted expression.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValueEvaluatableExpression struct {
+
+	// The document range for which the inline value applies.
+	// The range is used to extract the evaluatable expression from the underlying document.
+	Range Range `json:"range,omitempty"`
+
+	// If specified the expression overrides the extracted expression.
+	Expression *string `json:"expression,omitempty"`
+}
+
+/**
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesContext struct {
+
+	// The document range where execution has stopped.
+	// Typically the end position of the range denotes the line where the inline values are shown.
+	StoppedLocation Range `json:"stoppedLocation,omitempty"`
+}
+
+type integer int
+
+var integerStringMap = map[integer]string{
+	integerMIN_VALUE: "MIN_VALUE",
+	integerMAX_VALUE: "MAX_VALUE",
+}
+
+func (i integer) String() string {
+	if s, ok := integerStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	integerMIN_VALUE integer = -2147483648
+
+	integerMAX_VALUE integer = 2147483647
+)
+
+type uinteger int
+
+var uintegerStringMap = map[uinteger]string{
+	uintegerMIN_VALUE: "MIN_VALUE",
+	uintegerMAX_VALUE: "MAX_VALUE",
+}
+
+func (i uinteger) String() string {
+	if s, ok := uintegerStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	uintegerMIN_VALUE uinteger = 0
+
+	uintegerMAX_VALUE uinteger = 2147483647
+)
+
+/**
+ * Enum of known range kinds
+ */
+type FoldingRangeKind string
+
+const (
+	/**
+	 * Folding range for a comment
+	 */
+	FoldingRangeKindComment FoldingRangeKind = "comment"
+	/**
+	 * Folding range for a imports or includes
+	 */
+	FoldingRangeKindImports FoldingRangeKind = "imports"
+	/**
+	 * Folding range for a region (e.g. `#region`)
+	 */
+	FoldingRangeKindRegion FoldingRangeKind = "region"
+)
+
+/**
+ * The diagnostic's severity.
+ */
+type DiagnosticSeverity int
+
+var diagnosticSeverityStringMap = map[DiagnosticSeverity]string{
+	DiagnosticSeverityError:       "Error",
+	DiagnosticSeverityWarning:     "Warning",
+	DiagnosticSeverityInformation: "Information",
+	DiagnosticSeverityHint:        "Hint",
+}
+
+func (i DiagnosticSeverity) String() string {
+	if s, ok := diagnosticSeverityStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * Reports an error.
+	 */
+	DiagnosticSeverityError DiagnosticSeverity = 1
+	/**
+	 * Reports a warning.
+	 */
+	DiagnosticSeverityWarning DiagnosticSeverity = 2
+	/**
+	 * Reports an information.
+	 */
+	DiagnosticSeverityInformation DiagnosticSeverity = 3
+	/**
+	 * Reports a hint.
+	 */
+	DiagnosticSeverityHint DiagnosticSeverity = 4
+)
+
+/**
+ * The diagnostic tags.
+ *
+ * @since 3.15.0
+ */
+type DiagnosticTag int
+
+var diagnosticTagStringMap = map[DiagnosticTag]string{
+	DiagnosticTagUnnecessary: "Unnecessary",
+	DiagnosticTagDeprecated:  "Deprecated",
+}
+
+func (i DiagnosticTag) String() string {
+	if s, ok := diagnosticTagStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * Unused or unnecessary code.
+	 *
+	 * Clients are allowed to render diagnostics with this tag faded out instead of having
+	 * an error squiggle.
+	 */
+	DiagnosticTagUnnecessary DiagnosticTag = 1
+	/**
+	 * Deprecated or obsolete code.
+	 *
+	 * Clients are allowed to rendered diagnostics with this tag strike through.
+	 */
+	DiagnosticTagDeprecated DiagnosticTag = 2
+)
+
+/**
+ * A workspace edit represents changes to many resources managed in the workspace. The edit
+ * should either provide `changes` or `documentChanges`. If documentChanges are present
+ * they are preferred over `changes` if the client can handle versioned document edits.
+ *
+ * Since version 3.13.0 a workspace edit can contain resource operations as well. If resource
+ * operations are present clients need to execute the operations in the order in which they
+ * are provided. So a workspace edit for example can consist of the following two changes:
+ * (1) a create file a.txt and (2) a text document edit which insert text into file a.txt.
+ *
+ * An invalid sequence (e.g. (1) delete file a.txt and (2) insert text into file a.txt) will
+ * cause failure of the operation. How the client recovers from the failure is described by
+ * the client capability: `workspace.workspaceEdit.failureHandling`
+ */
+type WorkspaceEdit struct {
+	/**
+	 * Holds changes to existing resources.
+	 */
+	Changes *map[string] /*uri*/ []TextEdit `json:"changes,omitempty"`
+	/**
+	 * Depending on the client capability `workspace.workspaceEdit.resourceOperations` document changes
+	 * are either an array of `TextDocumentEdit`s to express changes to n different text documents
+	 * where each text document edit addresses a specific version of a text document. Or it can contain
+	 * above `TextDocumentEdit`s mixed with create, rename and delete file / folder operations.
+	 *
+	 * Whether a client supports versioned document edits is expressed via
+	 * `workspace.workspaceEdit.documentChanges` client capability.
+	 *
+	 * If a client neither supports `documentChanges` nor `workspace.workspaceEdit.resourceOperations` then
+	 * only plain `TextEdit`s using the `changes` property are supported.
+	 */
+	DocumentChanges *[]interface{} `json:"documentChanges,omitempty"` // (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)
+	/**
+	 * A map of change annotations that can be referenced in `AnnotatedTextEdit`s or create, rename and
+	 * delete file / folder operations.
+	 *
+	 * Whether clients honor this property depends on the client capability `workspace.changeAnnotationSupport`.
+	 *
+	 * @since 3.16.0
+	 */
+	ChangeAnnotations *map[ChangeAnnotationIdentifier]ChangeAnnotation `json:"changeAnnotations,omitempty"`
+}
+
+/**
+ * Represents a parameter of a callable-signature. A parameter can
+ * have a label and a doc-comment.
+ */
+type ParameterInformation struct {
+	/**
+	 * The label of this parameter information.
+	 *
+	 * Either a string or an inclusive start and exclusive end offsets within its containing
+	 * signature label. (see SignatureInformation.label). The offsets are based on a UTF-16
+	 * string representation as `Position` and `Range` does.
+	 *
+	 * *Note*: a label of type string should be a substring of its containing signature label.
+	 * Its intended use case is to highlight the parameter label part in the `SignatureInformation.label`.
+	 */
+	Label interface{} `json:"label,omitempty"` // string | [int, int]
+	/**
+	 * The human-readable doc-comment of this signature. Will be shown
+	 * in the UI but can be omitted.
+	 */
+	Documentation interface{} `json:"documentation,omitempty"` // string | MarkupContent
+}
+
+/**
+ * Describes textual changes on a text document. A TextDocumentEdit describes all changes
+ * on a document version Si and after they are applied move the document to version Si+1.
+ * So the creator of a TextDocumentEdit doesn't need to sort the array of edits or do any
+ * kind of ordering. However the edits must be non overlapping.
+ */
+type TextDocumentEdit struct {
+	/**
+	 * The text document to change.
+	 */
+	TextDocument OptionalVersionedTextDocumentIdentifier `json:"textDocument,omitempty"`
+
+	/**
+	 * The edits to be applied.
+	 *
+	 * @since 3.16.0 - support for AnnotatedTextEdit. This is guarded using a
+	 * client capability.
+	 */
+	Edits []interface{} `json:"edits,omitempty"` // (TextEdit | AnnotatedTextEdit)[]
+}
+
+/**
+ * A simple text document. Not to be implemented. The document keeps the content
+ * as string.
+ *
+ * @deprecated Use the text document from the new vscode-languageserver-textdocument package.
+ */
+type TextDocument struct {
+
+	// The associated URI for this document. Most documents have the __file__-scheme, indicating that they
+	// represent files on disk. However, some documents may have other schemes indicating that they are not
+	// available on disk.
+	//
+	// @readonly
+	Uri DocumentUri `json:"uri,omitempty"`
+
+	// The identifier of the language associated with this document.
+	//
+	// @readonly
+	LanguageId string `json:"languageId,omitempty"`
+
+	// The version number of this document (it will increase after each
+	// change, including undoredo).
+	//
+	// @readonly
+	Version int `json:"version,omitempty"`
+
+	// The number of lines in this document.
+	//
+	// @readonly
+	LineCount uint `json:"lineCount,omitempty"`
+}
+
+/**
+ * Describes the content type that a client supports in various
+ * result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
+ *
+ * Please note that `MarkupKinds` must not start with a `$`. This kinds
+ * are reserved for internal usage.
+ */
+type MarkupKind string
+
+const (
+	/**
+	 * Plain text is supported as a content format
+	 */
+	MarkupKindPlainText MarkupKind = "plaintext"
+	/**
+	 * Markdown is supported as a content format
+	 */
+	MarkupKindMarkdown MarkupKind = "markdown"
+)
+
+/**
+ * The kind of a completion entry.
+ */
+type CompletionItemKind int
+
+var completionItemKindStringMap = map[CompletionItemKind]string{
+	CompletionItemKindText:          "Text",
+	CompletionItemKindMethod:        "Method",
+	CompletionItemKindFunction:      "Function",
+	CompletionItemKindConstructor:   "Constructor",
+	CompletionItemKindField:         "Field",
+	CompletionItemKindVariable:      "Variable",
+	CompletionItemKindClass:         "Class",
+	CompletionItemKindInterface:     "Interface",
+	CompletionItemKindModule:        "Module",
+	CompletionItemKindProperty:      "Property",
+	CompletionItemKindUnit:          "Unit",
+	CompletionItemKindValue:         "Value",
+	CompletionItemKindEnum:          "Enum",
+	CompletionItemKindKeyword:       "Keyword",
+	CompletionItemKindSnippet:       "Snippet",
+	CompletionItemKindColor:         "Color",
+	CompletionItemKindFile:          "File",
+	CompletionItemKindReference:     "Reference",
+	CompletionItemKindFolder:        "Folder",
+	CompletionItemKindEnumMember:    "EnumMember",
+	CompletionItemKindConstant:      "Constant",
+	CompletionItemKindStruct:        "Struct",
+	CompletionItemKindEvent:         "Event",
+	CompletionItemKindOperator:      "Operator",
+	CompletionItemKindTypeParameter: "TypeParameter",
+}
+
+func (i CompletionItemKind) String() string {
+	if s, ok := completionItemKindStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	CompletionItemKindText CompletionItemKind = 1
+
+	CompletionItemKindMethod CompletionItemKind = 2
+
+	CompletionItemKindFunction CompletionItemKind = 3
+
+	CompletionItemKindConstructor CompletionItemKind = 4
+
+	CompletionItemKindField CompletionItemKind = 5
+
+	CompletionItemKindVariable CompletionItemKind = 6
+
+	CompletionItemKindClass CompletionItemKind = 7
+
+	CompletionItemKindInterface CompletionItemKind = 8
+
+	CompletionItemKindModule CompletionItemKind = 9
+
+	CompletionItemKindProperty CompletionItemKind = 10
+
+	CompletionItemKindUnit CompletionItemKind = 11
+
+	CompletionItemKindValue CompletionItemKind = 12
+
+	CompletionItemKindEnum CompletionItemKind = 13
+
+	CompletionItemKindKeyword CompletionItemKind = 14
+
+	CompletionItemKindSnippet CompletionItemKind = 15
+
+	CompletionItemKindColor CompletionItemKind = 16
+
+	CompletionItemKindFile CompletionItemKind = 17
+
+	CompletionItemKindReference CompletionItemKind = 18
+
+	CompletionItemKindFolder CompletionItemKind = 19
+
+	CompletionItemKindEnumMember CompletionItemKind = 20
+
+	CompletionItemKindConstant CompletionItemKind = 21
+
+	CompletionItemKindStruct CompletionItemKind = 22
+
+	CompletionItemKindEvent CompletionItemKind = 23
+
+	CompletionItemKindOperator CompletionItemKind = 24
+
+	CompletionItemKindTypeParameter CompletionItemKind = 25
+)
+
+/**
+ * Defines whether the insert text in a completion item should be interpreted as
+ * plain text or a snippet.
+ */
+type InsertTextFormat int
+
+var insertTextFormatStringMap = map[InsertTextFormat]string{
+	InsertTextFormatPlainText: "PlainText",
+	InsertTextFormatSnippet:   "Snippet",
+}
+
+func (i InsertTextFormat) String() string {
+	if s, ok := insertTextFormatStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * The primary text to be inserted is treated as a plain string.
+	 */
+	InsertTextFormatPlainText InsertTextFormat = 1
+	/**
+	 * The primary text to be inserted is treated as a snippet.
+	 *
+	 * A snippet can define tab stops and placeholders with `$1`, `$2`
+	 * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+	 * the end of the snippet. Placeholders with equal identifiers are linked,
+	 * that is typing in one will update others too.
+	 *
+	 * See also: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax
+	 */
+	InsertTextFormatSnippet InsertTextFormat = 2
+)
+
+/**
+ * Completion item tags are extra annotations that tweak the rendering of a completion
+ * item.
+ *
+ * @since 3.15.0
+ */
+type CompletionItemTag int
+
+var completionItemTagStringMap = map[CompletionItemTag]string{
+	CompletionItemTagDeprecated: "Deprecated",
+}
+
+func (i CompletionItemTag) String() string {
+	if s, ok := completionItemTagStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * Render a completion as obsolete, usually using a strike-out.
+	 */
+	CompletionItemTagDeprecated CompletionItemTag = 1
+)
+
+/**
+ * How whitespace and indentation is handled during completion
+ * item insertion.
+ *
+ * @since 3.16.0
+ */
+type InsertTextMode int
+
+var insertTextModeStringMap = map[InsertTextMode]string{
+	InsertTextModeAsIs:              "asIs",
+	InsertTextModeAdjustIndentation: "adjustIndentation",
+}
+
+func (i InsertTextMode) String() string {
+	if s, ok := insertTextModeStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * The insertion or replace strings is taken as it is. If the
+	 * value is multi line the lines below the cursor will be
+	 * inserted using the indentation defined in the string value.
+	 * The client will not apply any kind of adjustments to the
+	 * string.
+	 */
+	InsertTextModeAsIs InsertTextMode = 1
+	/**
+	 * The editor adjusts leading whitespace of new lines so that
+	 * they match the indentation up to the cursor of the line for
+	 * which the item is accepted.
+	 *
+	 * Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
+	 * multi line completion item is indented using 2 tabs and all
+	 * following lines inserted will be indented using 2 tabs as well.
+	 */
+	InsertTextModeAdjustIndentation InsertTextMode = 2
+)
+
+/**
+ * A document highlight kind.
+ */
+type DocumentHighlightKind int
+
+var documentHighlightKindStringMap = map[DocumentHighlightKind]string{
+	DocumentHighlightKindText:  "Text",
+	DocumentHighlightKindRead:  "Read",
+	DocumentHighlightKindWrite: "Write",
+}
+
+func (i DocumentHighlightKind) String() string {
+	if s, ok := documentHighlightKindStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * A textual occurrence.
+	 */
+	DocumentHighlightKindText DocumentHighlightKind = 1
+	/**
+	 * Read-access of a symbol, like reading a variable.
+	 */
+	DocumentHighlightKindRead DocumentHighlightKind = 2
+	/**
+	 * Write-access of a symbol, like writing to a variable.
+	 */
+	DocumentHighlightKindWrite DocumentHighlightKind = 3
+)
+
+/**
+ * A symbol kind.
+ */
+type SymbolKind int
+
+var symbolKindStringMap = map[SymbolKind]string{
+	SymbolKindFile:          "File",
+	SymbolKindModule:        "Module",
+	SymbolKindNamespace:     "Namespace",
+	SymbolKindPackage:       "Package",
+	SymbolKindClass:         "Class",
+	SymbolKindMethod:        "Method",
+	SymbolKindProperty:      "Property",
+	SymbolKindField:         "Field",
+	SymbolKindConstructor:   "Constructor",
+	SymbolKindEnum:          "Enum",
+	SymbolKindInterface:     "Interface",
+	SymbolKindFunction:      "Function",
+	SymbolKindVariable:      "Variable",
+	SymbolKindConstant:      "Constant",
+	SymbolKindString:        "String",
+	SymbolKindNumber:        "Number",
+	SymbolKindBoolean:       "Boolean",
+	SymbolKindArray:         "Array",
+	SymbolKindObject:        "Object",
+	SymbolKindKey:           "Key",
+	SymbolKindNull:          "Null",
+	SymbolKindEnumMember:    "EnumMember",
+	SymbolKindStruct:        "Struct",
+	SymbolKindEvent:         "Event",
+	SymbolKindOperator:      "Operator",
+	SymbolKindTypeParameter: "TypeParameter",
+}
+
+func (i SymbolKind) String() string {
+	if s, ok := symbolKindStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	SymbolKindFile SymbolKind = 1
+
+	SymbolKindModule SymbolKind = 2
+
+	SymbolKindNamespace SymbolKind = 3
+
+	SymbolKindPackage SymbolKind = 4
+
+	SymbolKindClass SymbolKind = 5
+
+	SymbolKindMethod SymbolKind = 6
+
+	SymbolKindProperty SymbolKind = 7
+
+	SymbolKindField SymbolKind = 8
+
+	SymbolKindConstructor SymbolKind = 9
+
+	SymbolKindEnum SymbolKind = 10
+
+	SymbolKindInterface SymbolKind = 11
+
+	SymbolKindFunction SymbolKind = 12
+
+	SymbolKindVariable SymbolKind = 13
+
+	SymbolKindConstant SymbolKind = 14
+
+	SymbolKindString SymbolKind = 15
+
+	SymbolKindNumber SymbolKind = 16
+
+	SymbolKindBoolean SymbolKind = 17
+
+	SymbolKindArray SymbolKind = 18
+
+	SymbolKindObject SymbolKind = 19
+
+	SymbolKindKey SymbolKind = 20
+
+	SymbolKindNull SymbolKind = 21
+
+	SymbolKindEnumMember SymbolKind = 22
+
+	SymbolKindStruct SymbolKind = 23
+
+	SymbolKindEvent SymbolKind = 24
+
+	SymbolKindOperator SymbolKind = 25
+
+	SymbolKindTypeParameter SymbolKind = 26
+)
+
+/**
+ * Symbol tags are extra annotations that tweak the rendering of a symbol.
+ * @since 3.16
+ */
+type SymbolTag int
+
+var symbolTagStringMap = map[SymbolTag]string{
+	SymbolTagDeprecated: "Deprecated",
+}
+
+func (i SymbolTag) String() string {
+	if s, ok := symbolTagStringMap[i]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+const (
+	/**
+	 * Render a symbol as obsolete, usually using a strike-out.
+	 */
+	SymbolTagDeprecated SymbolTag = 1
+)
+
+/**
+ * A set of predefined code action kinds
+ */
+type CodeActionKind string
+
+const (
+	/**
+	 * Empty kind.
+	 */
+	CodeActionKindEmpty CodeActionKind = ""
+	/**
+	 * Base kind for quickfix actions: 'quickfix'
+	 */
+	CodeActionKindQuickFix CodeActionKind = "quickfix"
+	/**
+	 * Base kind for refactoring actions: 'refactor'
+	 */
+	CodeActionKindRefactor CodeActionKind = "refactor"
+	/**
+	 * Base kind for refactoring extraction actions: 'refactor.extract'
+	 *
+	 * Example extract actions:
+	 *
+	 * - Extract method
+	 * - Extract function
+	 * - Extract variable
+	 * - Extract interface from class
+	 * - ...
+	 */
+	CodeActionKindRefactorExtract CodeActionKind = "refactor.extract"
+	/**
+	 * Base kind for refactoring inline actions: 'refactor.inline'
+	 *
+	 * Example inline actions:
+	 *
+	 * - Inline function
+	 * - Inline variable
+	 * - Inline constant
+	 * - ...
+	 */
+	CodeActionKindRefactorInline CodeActionKind = "refactor.inline"
+	/**
+	 * Base kind for refactoring rewrite actions: 'refactor.rewrite'
+	 *
+	 * Example rewrite actions:
+	 *
+	 * - Convert JavaScript function to class
+	 * - Add or remove parameter
+	 * - Encapsulate field
+	 * - Make method static
+	 * - Move method to base class
+	 * - ...
+	 */
+	CodeActionKindRefactorRewrite CodeActionKind = "refactor.rewrite"
+	/**
+	 * Base kind for source actions: `source`
+	 *
+	 * Source code actions apply to the entire file.
+	 */
+	CodeActionKindSource CodeActionKind = "source"
+	/**
+	 * Base kind for an organize imports source action: `source.organizeImports`
+	 */
+	CodeActionKindSourceOrganizeImports CodeActionKind = "source.organizeImports"
+	/**
+	 * Base kind for auto-fix source actions: `source.fixAll`.
+	 *
+	 * Fix all actions automatically fix errors that have a clear fix that do not require user input.
+	 * They should not suppress errors or perform unsafe fixes such as generating new types or classes.
+	 *
+	 * @since 3.15.0
+	 */
+	CodeActionKindSourceFixAll CodeActionKind = "source.fixAll"
+)
+
+/**
+ * A set of predefined token types. This set is not fixed
+ * an clients can specify additional token types via the
+ * corresponding client capabilities.
+ *
+ * @since 3.16.0
+ */
+type SemanticTokenTypes string
+
+const (
+	SemanticTokenTypesNamespace SemanticTokenTypes = "namespace"
+	/**
+	 * Represents a generic type. Acts as a fallback for types which can't be mapped to
+	 * a specific type like class or enum.
+	 */
+	SemanticTokenTypesType SemanticTokenTypes = "type"
+
+	SemanticTokenTypesClass SemanticTokenTypes = "class"
+
+	SemanticTokenTypesEnum SemanticTokenTypes = "enum"
+
+	SemanticTokenTypesInterface SemanticTokenTypes = "interface"
+
+	SemanticTokenTypesStruct SemanticTokenTypes = "struct"
+
+	SemanticTokenTypesTypeParameter SemanticTokenTypes = "typeParameter"
+
+	SemanticTokenTypesParameter SemanticTokenTypes = "parameter"
+
+	SemanticTokenTypesVariable SemanticTokenTypes = "variable"
+
+	SemanticTokenTypesProperty SemanticTokenTypes = "property"
+
+	SemanticTokenTypesEnumMember SemanticTokenTypes = "enumMember"
+
+	SemanticTokenTypesEvent SemanticTokenTypes = "event"
+
+	SemanticTokenTypesFunction SemanticTokenTypes = "function"
+
+	SemanticTokenTypesMethod SemanticTokenTypes = "method"
+
+	SemanticTokenTypesMacro SemanticTokenTypes = "macro"
+
+	SemanticTokenTypesKeyword SemanticTokenTypes = "keyword"
+
+	SemanticTokenTypesModifier SemanticTokenTypes = "modifier"
+
+	SemanticTokenTypesComment SemanticTokenTypes = "comment"
+
+	SemanticTokenTypesString SemanticTokenTypes = "string"
+
+	SemanticTokenTypesNumber SemanticTokenTypes = "number"
+
+	SemanticTokenTypesRegexp SemanticTokenTypes = "regexp"
+
+	SemanticTokenTypesOperator SemanticTokenTypes = "operator"
+	/**
+	 * @since 3.17.0
+	 */
+	SemanticTokenTypesDecorator SemanticTokenTypes = "decorator"
+)
+
+/**
+ * A set of predefined token modifiers. This set is not fixed
+ * an clients can specify additional token types via the
+ * corresponding client capabilities.
+ *
+ * @since 3.16.0
+ */
+type SemanticTokenModifiers string
+
+const (
+	SemanticTokenModifiersDeclaration SemanticTokenModifiers = "declaration"
+
+	SemanticTokenModifiersDefinition SemanticTokenModifiers = "definition"
+
+	SemanticTokenModifiersReadonly SemanticTokenModifiers = "readonly"
+
+	SemanticTokenModifiersStatic SemanticTokenModifiers = "static"
+
+	SemanticTokenModifiersDeprecated SemanticTokenModifiers = "deprecated"
+
+	SemanticTokenModifiersAbstract SemanticTokenModifiers = "abstract"
+
+	SemanticTokenModifiersAsync SemanticTokenModifiers = "async"
+
+	SemanticTokenModifiersModification SemanticTokenModifiers = "modification"
+
+	SemanticTokenModifiersDocumentation SemanticTokenModifiers = "documentation"
+
+	SemanticTokenModifiersDefaultLibrary SemanticTokenModifiers = "defaultLibrary"
+)

--- a/misc/regopls/lsp/generated_methods.go
+++ b/misc/regopls/lsp/generated_methods.go
@@ -1,0 +1,1249 @@
+// code gen by methods_gen_test.go, do not edit!
+package lsp
+
+import (
+	"context"
+
+	"github.com/open-policy-agent/opa/misc/regopls/jsonrpc"
+	"github.com/open-policy-agent/opa/misc/regopls/lsp/defines"
+)
+
+type Methods struct {
+	Opt                                        Options
+	onInitialize                               func(ctx context.Context, req *defines.InitializeParams) (*defines.InitializeResult, *defines.InitializeError)
+	onInitialized                              func(ctx context.Context, req *defines.InitializeParams) error
+	onShutdown                                 func(ctx context.Context, req *interface{}) error
+	onExit                                     func(ctx context.Context, req *interface{}) error
+	onDidChangeConfiguration                   func(ctx context.Context, req *defines.DidChangeConfigurationParams) error
+	onDidChangeWatchedFiles                    func(ctx context.Context, req *defines.DidChangeWatchedFilesParams) error
+	onDidOpenTextDocument                      func(ctx context.Context, req *defines.DidOpenTextDocumentParams) error
+	onDidChangeTextDocument                    func(ctx context.Context, req *defines.DidChangeTextDocumentParams) error
+	onDidCloseTextDocument                     func(ctx context.Context, req *defines.DidCloseTextDocumentParams) error
+	onWillSaveTextDocument                     func(ctx context.Context, req *defines.WillSaveTextDocumentParams) error
+	onDidSaveTextDocument                      func(ctx context.Context, req *defines.DidSaveTextDocumentParams) error
+	onExecuteCommand                           func(ctx context.Context, req *defines.ExecuteCommandParams) error
+	onHover                                    func(ctx context.Context, req *defines.HoverParams) (*defines.Hover, error)
+	onCompletion                               func(ctx context.Context, req *defines.CompletionParams) (*[]defines.CompletionItem, error)
+	onCompletionResolve                        func(ctx context.Context, req *defines.CompletionItem) (*defines.CompletionItem, error)
+	onSignatureHelp                            func(ctx context.Context, req *defines.SignatureHelpParams) (*defines.SignatureHelp, error)
+	onDeclaration                              func(ctx context.Context, req *defines.DeclarationParams) (*[]defines.LocationLink, error)
+	onDefinition                               func(ctx context.Context, req *defines.DefinitionParams) (*[]defines.LocationLink, error)
+	onTypeDefinition                           func(ctx context.Context, req *defines.TypeDefinitionParams) (*[]defines.LocationLink, error)
+	onImplementation                           func(ctx context.Context, req *defines.ImplementationParams) (*[]defines.LocationLink, error)
+	onReferences                               func(ctx context.Context, req *defines.ReferenceParams) (*[]defines.Location, error)
+	onDocumentHighlight                        func(ctx context.Context, req *defines.DocumentHighlightParams) (*[]defines.DocumentHighlight, error)
+	onDocumentSymbolWithSliceDocumentSymbol    func(ctx context.Context, req *defines.DocumentSymbolParams) (*[]defines.DocumentSymbol, error)
+	onDocumentSymbolWithSliceSymbolInformation func(ctx context.Context, req *defines.DocumentSymbolParams) (*[]defines.SymbolInformation, error)
+	onWorkspaceSymbol                          func(ctx context.Context, req *defines.WorkspaceSymbolParams) (*[]defines.SymbolInformation, error)
+	onCodeActionWithSliceCommand               func(ctx context.Context, req *defines.CodeActionParams) (*[]defines.Command, error)
+	onCodeActionWithSliceCodeAction            func(ctx context.Context, req *defines.CodeActionParams) (*[]defines.CodeAction, error)
+	onCodeActionResolve                        func(ctx context.Context, req *defines.CodeAction) (*defines.CodeAction, error)
+	onCodeLens                                 func(ctx context.Context, req *defines.CodeLensParams) (*[]defines.CodeLens, error)
+	onCodeLensResolve                          func(ctx context.Context, req *defines.CodeLens) (*defines.CodeLens, error)
+	onDocumentFormatting                       func(ctx context.Context, req *defines.DocumentFormattingParams) (*[]defines.TextEdit, error)
+	onDocumentRangeFormatting                  func(ctx context.Context, req *defines.DocumentRangeFormattingParams) (*[]defines.TextEdit, error)
+	onDocumentOnTypeFormatting                 func(ctx context.Context, req *defines.DocumentOnTypeFormattingParams) (*[]defines.TextEdit, error)
+	onRenameRequest                            func(ctx context.Context, req *defines.RenameParams) (*defines.WorkspaceEdit, error)
+	onPrepareRename                            func(ctx context.Context, req *defines.PrepareRenameParams) (*defines.Range, error)
+	onDocumentLinks                            func(ctx context.Context, req *defines.DocumentLinkParams) (*[]defines.DocumentLink, error)
+	onDocumentLinkResolve                      func(ctx context.Context, req *defines.DocumentLink) (*defines.DocumentLink, error)
+	onDocumentColor                            func(ctx context.Context, req *defines.DocumentColorParams) (*[]defines.ColorInformation, error)
+	onColorPresentation                        func(ctx context.Context, req *defines.ColorPresentationParams) (*[]defines.ColorPresentation, error)
+	onFoldingRanges                            func(ctx context.Context, req *defines.FoldingRangeParams) (*[]defines.FoldingRange, error)
+	onSelectionRanges                          func(ctx context.Context, req *defines.SelectionRangeParams) (*[]defines.SelectionRange, error)
+}
+
+func (m *Methods) OnInitialize(f func(ctx context.Context, req *defines.InitializeParams) (result *defines.InitializeResult, err *defines.InitializeError)) {
+	m.onInitialize = f
+}
+
+func (m *Methods) initialize(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.InitializeParams)
+	if m.onInitialize != nil {
+		res, err := m.onInitialize(ctx, params)
+		e := wrapErrorToRespError(err, 1)
+		return res, e
+	}
+
+	res, err := m.builtinInitialize(ctx, params)
+	e := wrapErrorToRespError(err, 1)
+	return res, e
+
+}
+
+func (m *Methods) initializeMethodInfo() *jsonrpc.MethodInfo {
+
+	return &jsonrpc.MethodInfo{
+		Name: "initialize",
+		NewRequest: func() interface{} {
+			return &defines.InitializeParams{}
+		},
+		Handler: m.initialize,
+	}
+}
+
+func (m *Methods) OnInitialized(f func(ctx context.Context, req *defines.InitializeParams) (err error)) {
+	m.onInitialized = f
+}
+
+func (m *Methods) initialized(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.InitializeParams)
+	if m.onInitialized != nil {
+		err := m.onInitialized(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) initializedMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onInitialized == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "initialized",
+		NewRequest: func() interface{} {
+			return &defines.InitializeParams{}
+		},
+		Handler: m.initialized,
+	}
+}
+
+func (m *Methods) OnShutdown(f func(ctx context.Context, req *interface{}) (err error)) {
+	m.onShutdown = f
+}
+
+func (m *Methods) shutdown(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*interface{})
+	if m.onShutdown != nil {
+		err := m.onShutdown(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) shutdownMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onShutdown == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "shutdown",
+		NewRequest: func() interface{} {
+			return nil
+		},
+		Handler: m.shutdown,
+	}
+}
+
+func (m *Methods) OnExit(f func(ctx context.Context, req *interface{}) (err error)) {
+	m.onExit = f
+}
+
+func (m *Methods) exit(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*interface{})
+	if m.onExit != nil {
+		err := m.onExit(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) exitMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onExit == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "exit",
+		NewRequest: func() interface{} {
+			return nil
+		},
+		Handler: m.exit,
+	}
+}
+
+func (m *Methods) OnDidChangeConfiguration(f func(ctx context.Context, req *defines.DidChangeConfigurationParams) (err error)) {
+	m.onDidChangeConfiguration = f
+}
+
+func (m *Methods) didChangeConfiguration(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DidChangeConfigurationParams)
+	if m.onDidChangeConfiguration != nil {
+		err := m.onDidChangeConfiguration(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) didChangeConfigurationMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDidChangeConfiguration == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "didChangeConfiguration",
+		NewRequest: func() interface{} {
+			return &defines.DidChangeConfigurationParams{}
+		},
+		Handler: m.didChangeConfiguration,
+	}
+}
+
+func (m *Methods) OnDidChangeWatchedFiles(f func(ctx context.Context, req *defines.DidChangeWatchedFilesParams) (err error)) {
+	m.onDidChangeWatchedFiles = f
+}
+
+func (m *Methods) didChangeWatchedFiles(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DidChangeWatchedFilesParams)
+	if m.onDidChangeWatchedFiles != nil {
+		err := m.onDidChangeWatchedFiles(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) didChangeWatchedFilesMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDidChangeWatchedFiles == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "didChangeWatchedFiles",
+		NewRequest: func() interface{} {
+			return &defines.DidChangeWatchedFilesParams{}
+		},
+		Handler: m.didChangeWatchedFiles,
+	}
+}
+
+func (m *Methods) OnDidOpenTextDocument(f func(ctx context.Context, req *defines.DidOpenTextDocumentParams) (err error)) {
+	m.onDidOpenTextDocument = f
+}
+
+func (m *Methods) didOpenTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DidOpenTextDocumentParams)
+	if m.onDidOpenTextDocument != nil {
+		err := m.onDidOpenTextDocument(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) didOpenTextDocumentMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDidOpenTextDocument == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "didOpenTextDocument",
+		NewRequest: func() interface{} {
+			return &defines.DidOpenTextDocumentParams{}
+		},
+		Handler: m.didOpenTextDocument,
+	}
+}
+
+func (m *Methods) OnDidChangeTextDocument(f func(ctx context.Context, req *defines.DidChangeTextDocumentParams) (err error)) {
+	m.onDidChangeTextDocument = f
+}
+
+func (m *Methods) didChangeTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DidChangeTextDocumentParams)
+	if m.onDidChangeTextDocument != nil {
+		err := m.onDidChangeTextDocument(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) didChangeTextDocumentMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDidChangeTextDocument == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "didChangeTextDocument",
+		NewRequest: func() interface{} {
+			return &defines.DidChangeTextDocumentParams{}
+		},
+		Handler: m.didChangeTextDocument,
+	}
+}
+
+func (m *Methods) OnDidCloseTextDocument(f func(ctx context.Context, req *defines.DidCloseTextDocumentParams) (err error)) {
+	m.onDidCloseTextDocument = f
+}
+
+func (m *Methods) didCloseTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DidCloseTextDocumentParams)
+	if m.onDidCloseTextDocument != nil {
+		err := m.onDidCloseTextDocument(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) didCloseTextDocumentMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDidCloseTextDocument == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "didCloseTextDocument",
+		NewRequest: func() interface{} {
+			return &defines.DidCloseTextDocumentParams{}
+		},
+		Handler: m.didCloseTextDocument,
+	}
+}
+
+func (m *Methods) OnWillSaveTextDocument(f func(ctx context.Context, req *defines.WillSaveTextDocumentParams) (err error)) {
+	m.onWillSaveTextDocument = f
+}
+
+func (m *Methods) willSaveTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.WillSaveTextDocumentParams)
+	if m.onWillSaveTextDocument != nil {
+		err := m.onWillSaveTextDocument(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) willSaveTextDocumentMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onWillSaveTextDocument == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "willSaveTextDocument",
+		NewRequest: func() interface{} {
+			return &defines.WillSaveTextDocumentParams{}
+		},
+		Handler: m.willSaveTextDocument,
+	}
+}
+
+func (m *Methods) OnDidSaveTextDocument(f func(ctx context.Context, req *defines.DidSaveTextDocumentParams) (err error)) {
+	m.onDidSaveTextDocument = f
+}
+
+func (m *Methods) didSaveTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DidSaveTextDocumentParams)
+	if m.onDidSaveTextDocument != nil {
+		err := m.onDidSaveTextDocument(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) didSaveTextDocumentMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDidSaveTextDocument == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "didSaveTextDocument",
+		NewRequest: func() interface{} {
+			return &defines.DidSaveTextDocumentParams{}
+		},
+		Handler: m.didSaveTextDocument,
+	}
+}
+
+func (m *Methods) OnExecuteCommand(f func(ctx context.Context, req *defines.ExecuteCommandParams) (err error)) {
+	m.onExecuteCommand = f
+}
+
+func (m *Methods) executeCommand(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.ExecuteCommandParams)
+	if m.onExecuteCommand != nil {
+		err := m.onExecuteCommand(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return nil, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) executeCommandMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onExecuteCommand == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "executeCommand",
+		NewRequest: func() interface{} {
+			return &defines.ExecuteCommandParams{}
+		},
+		Handler: m.executeCommand,
+	}
+}
+
+func (m *Methods) OnHover(f func(ctx context.Context, req *defines.HoverParams) (result *defines.Hover, err error)) {
+	m.onHover = f
+}
+
+func (m *Methods) hover(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.HoverParams)
+	if m.onHover != nil {
+		res, err := m.onHover(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) hoverMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onHover == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/hover",
+		NewRequest: func() interface{} {
+			return &defines.HoverParams{}
+		},
+		Handler: m.hover,
+	}
+}
+
+func (m *Methods) OnCompletion(f func(ctx context.Context, req *defines.CompletionParams) (result *[]defines.CompletionItem, err error)) {
+	m.onCompletion = f
+}
+
+func (m *Methods) completion(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.CompletionParams)
+	if m.onCompletion != nil {
+		res, err := m.onCompletion(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) completionMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onCompletion == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/completion",
+		NewRequest: func() interface{} {
+			return &defines.CompletionParams{}
+		},
+		Handler: m.completion,
+	}
+}
+
+func (m *Methods) OnCompletionResolve(f func(ctx context.Context, req *defines.CompletionItem) (result *defines.CompletionItem, err error)) {
+	m.onCompletionResolve = f
+}
+
+func (m *Methods) completionResolve(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.CompletionItem)
+	if m.onCompletionResolve != nil {
+		res, err := m.onCompletionResolve(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) completionResolveMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onCompletionResolve == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "completionItem/resolve",
+		NewRequest: func() interface{} {
+			return &defines.CompletionItem{}
+		},
+		Handler: m.completionResolve,
+	}
+}
+
+func (m *Methods) OnSignatureHelp(f func(ctx context.Context, req *defines.SignatureHelpParams) (result *defines.SignatureHelp, err error)) {
+	m.onSignatureHelp = f
+}
+
+func (m *Methods) signatureHelp(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.SignatureHelpParams)
+	if m.onSignatureHelp != nil {
+		res, err := m.onSignatureHelp(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) signatureHelpMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onSignatureHelp == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/signatureHelp",
+		NewRequest: func() interface{} {
+			return &defines.SignatureHelpParams{}
+		},
+		Handler: m.signatureHelp,
+	}
+}
+
+func (m *Methods) OnDeclaration(f func(ctx context.Context, req *defines.DeclarationParams) (result *[]defines.LocationLink, err error)) {
+	m.onDeclaration = f
+}
+
+func (m *Methods) declaration(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DeclarationParams)
+	if m.onDeclaration != nil {
+		res, err := m.onDeclaration(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) declarationMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDeclaration == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/declaration",
+		NewRequest: func() interface{} {
+			return &defines.DeclarationParams{}
+		},
+		Handler: m.declaration,
+	}
+}
+
+func (m *Methods) OnDefinition(f func(ctx context.Context, req *defines.DefinitionParams) (result *[]defines.LocationLink, err error)) {
+	m.onDefinition = f
+}
+
+func (m *Methods) definition(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DefinitionParams)
+	if m.onDefinition != nil {
+		res, err := m.onDefinition(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) definitionMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDefinition == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/definition",
+		NewRequest: func() interface{} {
+			return &defines.DefinitionParams{}
+		},
+		Handler: m.definition,
+	}
+}
+
+func (m *Methods) OnTypeDefinition(f func(ctx context.Context, req *defines.TypeDefinitionParams) (result *[]defines.LocationLink, err error)) {
+	m.onTypeDefinition = f
+}
+
+func (m *Methods) typeDefinition(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.TypeDefinitionParams)
+	if m.onTypeDefinition != nil {
+		res, err := m.onTypeDefinition(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) typeDefinitionMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onTypeDefinition == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/typeDefinition",
+		NewRequest: func() interface{} {
+			return &defines.TypeDefinitionParams{}
+		},
+		Handler: m.typeDefinition,
+	}
+}
+
+func (m *Methods) OnImplementation(f func(ctx context.Context, req *defines.ImplementationParams) (result *[]defines.LocationLink, err error)) {
+	m.onImplementation = f
+}
+
+func (m *Methods) implementation(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.ImplementationParams)
+	if m.onImplementation != nil {
+		res, err := m.onImplementation(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) implementationMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onImplementation == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/implementation",
+		NewRequest: func() interface{} {
+			return &defines.ImplementationParams{}
+		},
+		Handler: m.implementation,
+	}
+}
+
+func (m *Methods) OnReferences(f func(ctx context.Context, req *defines.ReferenceParams) (result *[]defines.Location, err error)) {
+	m.onReferences = f
+}
+
+func (m *Methods) references(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.ReferenceParams)
+	if m.onReferences != nil {
+		res, err := m.onReferences(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) referencesMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onReferences == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/references",
+		NewRequest: func() interface{} {
+			return &defines.ReferenceParams{}
+		},
+		Handler: m.references,
+	}
+}
+
+func (m *Methods) OnDocumentHighlight(f func(ctx context.Context, req *defines.DocumentHighlightParams) (result *[]defines.DocumentHighlight, err error)) {
+	m.onDocumentHighlight = f
+}
+
+func (m *Methods) documentHighlight(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DocumentHighlightParams)
+	if m.onDocumentHighlight != nil {
+		res, err := m.onDocumentHighlight(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) documentHighlightMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDocumentHighlight == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/documentHighlight",
+		NewRequest: func() interface{} {
+			return &defines.DocumentHighlightParams{}
+		},
+		Handler: m.documentHighlight,
+	}
+}
+
+func (m *Methods) OnDocumentSymbolWithSliceDocumentSymbol(f func(ctx context.Context, req *defines.DocumentSymbolParams) (result *[]defines.DocumentSymbol, err error)) {
+	m.onDocumentSymbolWithSliceDocumentSymbol = f
+}
+
+func (m *Methods) documentSymbolWithSliceDocumentSymbol(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DocumentSymbolParams)
+	if m.onDocumentSymbolWithSliceDocumentSymbol != nil {
+		res, err := m.onDocumentSymbolWithSliceDocumentSymbol(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) documentSymbolWithSliceDocumentSymbolMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDocumentSymbolWithSliceDocumentSymbol == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/documentSymbol",
+		NewRequest: func() interface{} {
+			return &defines.DocumentSymbolParams{}
+		},
+		Handler: m.documentSymbolWithSliceDocumentSymbol,
+	}
+}
+
+func (m *Methods) OnDocumentSymbolWithSliceSymbolInformation(f func(ctx context.Context, req *defines.DocumentSymbolParams) (result *[]defines.SymbolInformation, err error)) {
+	m.onDocumentSymbolWithSliceSymbolInformation = f
+}
+
+func (m *Methods) documentSymbolWithSliceSymbolInformation(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DocumentSymbolParams)
+	if m.onDocumentSymbolWithSliceSymbolInformation != nil {
+		res, err := m.onDocumentSymbolWithSliceSymbolInformation(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) documentSymbolWithSliceSymbolInformationMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDocumentSymbolWithSliceSymbolInformation == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/documentSymbol",
+		NewRequest: func() interface{} {
+			return &defines.DocumentSymbolParams{}
+		},
+		Handler: m.documentSymbolWithSliceSymbolInformation,
+	}
+}
+
+func (m *Methods) OnWorkspaceSymbol(f func(ctx context.Context, req *defines.WorkspaceSymbolParams) (result *[]defines.SymbolInformation, err error)) {
+	m.onWorkspaceSymbol = f
+}
+
+func (m *Methods) workspaceSymbol(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.WorkspaceSymbolParams)
+	if m.onWorkspaceSymbol != nil {
+		res, err := m.onWorkspaceSymbol(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) workspaceSymbolMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onWorkspaceSymbol == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "workspace/symbol",
+		NewRequest: func() interface{} {
+			return &defines.WorkspaceSymbolParams{}
+		},
+		Handler: m.workspaceSymbol,
+	}
+}
+
+func (m *Methods) OnCodeActionWithSliceCommand(f func(ctx context.Context, req *defines.CodeActionParams) (result *[]defines.Command, err error)) {
+	m.onCodeActionWithSliceCommand = f
+}
+
+func (m *Methods) codeActionWithSliceCommand(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.CodeActionParams)
+	if m.onCodeActionWithSliceCommand != nil {
+		res, err := m.onCodeActionWithSliceCommand(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) codeActionWithSliceCommandMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onCodeActionWithSliceCommand == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/codeAction",
+		NewRequest: func() interface{} {
+			return &defines.CodeActionParams{}
+		},
+		Handler: m.codeActionWithSliceCommand,
+	}
+}
+
+func (m *Methods) OnCodeActionWithSliceCodeAction(f func(ctx context.Context, req *defines.CodeActionParams) (result *[]defines.CodeAction, err error)) {
+	m.onCodeActionWithSliceCodeAction = f
+}
+
+func (m *Methods) codeActionWithSliceCodeAction(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.CodeActionParams)
+	if m.onCodeActionWithSliceCodeAction != nil {
+		res, err := m.onCodeActionWithSliceCodeAction(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) codeActionWithSliceCodeActionMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onCodeActionWithSliceCodeAction == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/codeAction",
+		NewRequest: func() interface{} {
+			return &defines.CodeActionParams{}
+		},
+		Handler: m.codeActionWithSliceCodeAction,
+	}
+}
+
+func (m *Methods) OnCodeActionResolve(f func(ctx context.Context, req *defines.CodeAction) (result *defines.CodeAction, err error)) {
+	m.onCodeActionResolve = f
+}
+
+func (m *Methods) codeActionResolve(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.CodeAction)
+	if m.onCodeActionResolve != nil {
+		res, err := m.onCodeActionResolve(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) codeActionResolveMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onCodeActionResolve == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "codeAction/resolve",
+		NewRequest: func() interface{} {
+			return &defines.CodeAction{}
+		},
+		Handler: m.codeActionResolve,
+	}
+}
+
+func (m *Methods) OnCodeLens(f func(ctx context.Context, req *defines.CodeLensParams) (result *[]defines.CodeLens, err error)) {
+	m.onCodeLens = f
+}
+
+func (m *Methods) codeLens(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.CodeLensParams)
+	if m.onCodeLens != nil {
+		res, err := m.onCodeLens(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) codeLensMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onCodeLens == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/codeLens",
+		NewRequest: func() interface{} {
+			return &defines.CodeLensParams{}
+		},
+		Handler: m.codeLens,
+	}
+}
+
+func (m *Methods) OnCodeLensResolve(f func(ctx context.Context, req *defines.CodeLens) (result *defines.CodeLens, err error)) {
+	m.onCodeLensResolve = f
+}
+
+func (m *Methods) codeLensResolve(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.CodeLens)
+	if m.onCodeLensResolve != nil {
+		res, err := m.onCodeLensResolve(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) codeLensResolveMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onCodeLensResolve == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "codeLens/resolve",
+		NewRequest: func() interface{} {
+			return &defines.CodeLens{}
+		},
+		Handler: m.codeLensResolve,
+	}
+}
+
+func (m *Methods) OnDocumentFormatting(f func(ctx context.Context, req *defines.DocumentFormattingParams) (result *[]defines.TextEdit, err error)) {
+	m.onDocumentFormatting = f
+}
+
+func (m *Methods) documentFormatting(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DocumentFormattingParams)
+	if m.onDocumentFormatting != nil {
+		res, err := m.onDocumentFormatting(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) documentFormattingMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDocumentFormatting == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/formatting",
+		NewRequest: func() interface{} {
+			return &defines.DocumentFormattingParams{}
+		},
+		Handler: m.documentFormatting,
+	}
+}
+
+func (m *Methods) OnDocumentRangeFormatting(f func(ctx context.Context, req *defines.DocumentRangeFormattingParams) (result *[]defines.TextEdit, err error)) {
+	m.onDocumentRangeFormatting = f
+}
+
+func (m *Methods) documentRangeFormatting(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DocumentRangeFormattingParams)
+	if m.onDocumentRangeFormatting != nil {
+		res, err := m.onDocumentRangeFormatting(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) documentRangeFormattingMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDocumentRangeFormatting == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/rangeFormatting",
+		NewRequest: func() interface{} {
+			return &defines.DocumentRangeFormattingParams{}
+		},
+		Handler: m.documentRangeFormatting,
+	}
+}
+
+func (m *Methods) OnDocumentOnTypeFormatting(f func(ctx context.Context, req *defines.DocumentOnTypeFormattingParams) (result *[]defines.TextEdit, err error)) {
+	m.onDocumentOnTypeFormatting = f
+}
+
+func (m *Methods) documentOnTypeFormatting(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DocumentOnTypeFormattingParams)
+	if m.onDocumentOnTypeFormatting != nil {
+		res, err := m.onDocumentOnTypeFormatting(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) documentOnTypeFormattingMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDocumentOnTypeFormatting == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/onTypeFormatting",
+		NewRequest: func() interface{} {
+			return &defines.DocumentOnTypeFormattingParams{}
+		},
+		Handler: m.documentOnTypeFormatting,
+	}
+}
+
+func (m *Methods) OnRenameRequest(f func(ctx context.Context, req *defines.RenameParams) (result *defines.WorkspaceEdit, err error)) {
+	m.onRenameRequest = f
+}
+
+func (m *Methods) renameRequest(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.RenameParams)
+	if m.onRenameRequest != nil {
+		res, err := m.onRenameRequest(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) renameRequestMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onRenameRequest == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/rename",
+		NewRequest: func() interface{} {
+			return &defines.RenameParams{}
+		},
+		Handler: m.renameRequest,
+	}
+}
+
+func (m *Methods) OnPrepareRename(f func(ctx context.Context, req *defines.PrepareRenameParams) (result *defines.Range, err error)) {
+	m.onPrepareRename = f
+}
+
+func (m *Methods) prepareRename(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.PrepareRenameParams)
+	if m.onPrepareRename != nil {
+		res, err := m.onPrepareRename(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) prepareRenameMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onPrepareRename == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/rename",
+		NewRequest: func() interface{} {
+			return &defines.PrepareRenameParams{}
+		},
+		Handler: m.prepareRename,
+	}
+}
+
+func (m *Methods) OnDocumentLinks(f func(ctx context.Context, req *defines.DocumentLinkParams) (result *[]defines.DocumentLink, err error)) {
+	m.onDocumentLinks = f
+}
+
+func (m *Methods) documentLinks(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DocumentLinkParams)
+	if m.onDocumentLinks != nil {
+		res, err := m.onDocumentLinks(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) documentLinksMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDocumentLinks == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/documentLink",
+		NewRequest: func() interface{} {
+			return &defines.DocumentLinkParams{}
+		},
+		Handler: m.documentLinks,
+	}
+}
+
+func (m *Methods) OnDocumentLinkResolve(f func(ctx context.Context, req *defines.DocumentLink) (result *defines.DocumentLink, err error)) {
+	m.onDocumentLinkResolve = f
+}
+
+func (m *Methods) documentLinkResolve(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DocumentLink)
+	if m.onDocumentLinkResolve != nil {
+		res, err := m.onDocumentLinkResolve(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) documentLinkResolveMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDocumentLinkResolve == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "documentLink/resolve",
+		NewRequest: func() interface{} {
+			return &defines.DocumentLink{}
+		},
+		Handler: m.documentLinkResolve,
+	}
+}
+
+func (m *Methods) OnDocumentColor(f func(ctx context.Context, req *defines.DocumentColorParams) (result *[]defines.ColorInformation, err error)) {
+	m.onDocumentColor = f
+}
+
+func (m *Methods) documentColor(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.DocumentColorParams)
+	if m.onDocumentColor != nil {
+		res, err := m.onDocumentColor(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) documentColorMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onDocumentColor == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/documentColor",
+		NewRequest: func() interface{} {
+			return &defines.DocumentColorParams{}
+		},
+		Handler: m.documentColor,
+	}
+}
+
+func (m *Methods) OnColorPresentation(f func(ctx context.Context, req *defines.ColorPresentationParams) (result *[]defines.ColorPresentation, err error)) {
+	m.onColorPresentation = f
+}
+
+func (m *Methods) colorPresentation(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.ColorPresentationParams)
+	if m.onColorPresentation != nil {
+		res, err := m.onColorPresentation(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) colorPresentationMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onColorPresentation == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/colorPresentation",
+		NewRequest: func() interface{} {
+			return &defines.ColorPresentationParams{}
+		},
+		Handler: m.colorPresentation,
+	}
+}
+
+func (m *Methods) OnFoldingRanges(f func(ctx context.Context, req *defines.FoldingRangeParams) (result *[]defines.FoldingRange, err error)) {
+	m.onFoldingRanges = f
+}
+
+func (m *Methods) foldingRanges(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.FoldingRangeParams)
+	if m.onFoldingRanges != nil {
+		res, err := m.onFoldingRanges(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) foldingRangesMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onFoldingRanges == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/foldingRange",
+		NewRequest: func() interface{} {
+			return &defines.FoldingRangeParams{}
+		},
+		Handler: m.foldingRanges,
+	}
+}
+
+func (m *Methods) OnSelectionRanges(f func(ctx context.Context, req *defines.SelectionRangeParams) (result *[]defines.SelectionRange, err error)) {
+	m.onSelectionRanges = f
+}
+
+func (m *Methods) selectionRanges(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*defines.SelectionRangeParams)
+	if m.onSelectionRanges != nil {
+		res, err := m.onSelectionRanges(ctx, params)
+		e := wrapErrorToRespError(err, 0)
+		return res, e
+	}
+	return nil, nil
+}
+
+func (m *Methods) selectionRangesMethodInfo() *jsonrpc.MethodInfo {
+
+	if m.onSelectionRanges == nil {
+		return nil
+	}
+	return &jsonrpc.MethodInfo{
+		Name: "textDocument/selectionRange",
+		NewRequest: func() interface{} {
+			return &defines.SelectionRangeParams{}
+		},
+		Handler: m.selectionRanges,
+	}
+}
+
+func (m *Methods) GetMethods() []*jsonrpc.MethodInfo {
+	return []*jsonrpc.MethodInfo{
+		m.initializeMethodInfo(),
+		m.initializedMethodInfo(),
+		m.shutdownMethodInfo(),
+		m.exitMethodInfo(),
+		m.didChangeConfigurationMethodInfo(),
+		m.didChangeWatchedFilesMethodInfo(),
+		m.didOpenTextDocumentMethodInfo(),
+		m.didChangeTextDocumentMethodInfo(),
+		m.didCloseTextDocumentMethodInfo(),
+		m.willSaveTextDocumentMethodInfo(),
+		m.didSaveTextDocumentMethodInfo(),
+		m.executeCommandMethodInfo(),
+		m.hoverMethodInfo(),
+		m.completionMethodInfo(),
+		m.completionResolveMethodInfo(),
+		m.signatureHelpMethodInfo(),
+		m.declarationMethodInfo(),
+		m.definitionMethodInfo(),
+		m.typeDefinitionMethodInfo(),
+		m.implementationMethodInfo(),
+		m.referencesMethodInfo(),
+		m.documentHighlightMethodInfo(),
+		m.documentSymbolWithSliceDocumentSymbolMethodInfo(),
+		m.documentSymbolWithSliceSymbolInformationMethodInfo(),
+		m.workspaceSymbolMethodInfo(),
+		m.codeActionWithSliceCommandMethodInfo(),
+		m.codeActionWithSliceCodeActionMethodInfo(),
+		m.codeActionResolveMethodInfo(),
+		m.codeLensMethodInfo(),
+		m.codeLensResolveMethodInfo(),
+		m.documentFormattingMethodInfo(),
+		m.documentRangeFormattingMethodInfo(),
+		m.documentOnTypeFormattingMethodInfo(),
+		m.renameRequestMethodInfo(),
+		m.prepareRenameMethodInfo(),
+		m.documentLinksMethodInfo(),
+		m.documentLinkResolveMethodInfo(),
+		m.documentColorMethodInfo(),
+		m.colorPresentationMethodInfo(),
+		m.foldingRangesMethodInfo(),
+		m.selectionRangesMethodInfo(),
+	}
+}

--- a/misc/regopls/lsp/method_placeholders.go
+++ b/misc/regopls/lsp/method_placeholders.go
@@ -1,0 +1,87 @@
+package lsp
+
+const structItemTemp = `	on%s func(ctx context.Context, req *%s) (*%s, %s)`
+
+const noRespStructItemTemp = `	on%s func(ctx context.Context, req *%s) %s`
+
+const structTemp = `
+type Methods struct {
+    Opt Options
+%s
+}
+`
+
+const methodsTemp = `
+func (m *Methods) On%s(f func(ctx context.Context, req *%s) (result *%s, err %s)) {
+	m.on%s = f
+}
+`
+
+const noRespMethodsTemp = `
+func (m *Methods) On%s(f func(ctx context.Context, req *%s) (err %s)) {
+	m.on%s = f
+}
+`
+
+const jsonrpcHandlerTemp = `
+func (m *Methods) %s(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*%s)
+	if m.on%s != nil {
+		res, err := m.on%s(ctx, params)
+		e := wrapErrorToRespError(err, %s)
+		return res, e
+	}
+%s
+}
+`
+
+const builtinTemp = `
+	res, err := m.builtin%s(ctx, params)
+	e := wrapErrorToRespError(err, %s)
+	return res, e
+`
+
+const noRespBuiltinTemp = `
+	err := m.builtin%s(ctx, params)
+	e := wrapErrorToRespError(err, %s)
+	return nil, e
+`
+const noBuiltinTemp = `    return nil, nil`
+
+const noRespJsonrpcHandlerTemp = `
+func (m *Methods) %s(ctx context.Context, req interface{}) (interface{}, error) {
+	params := req.(*%s)
+	if m.on%s != nil {
+		err := m.on%s(ctx, params)
+		e := wrapErrorToRespError(err, %s)
+		return nil, e
+	}
+%s
+}
+`
+
+const methodInfoDefaultTemp = `
+    if m.on%s == nil{
+		return nil
+	}`
+
+const methodsInfoTemp = `
+func (m *Methods) %sMethodInfo() *jsonrpc.MethodInfo {
+%s
+    return &jsonrpc.MethodInfo{
+		Name: "%s",
+		NewRequest: func() interface{} {
+			return %s
+		},
+		Handler: m.%s,
+	}
+}
+`
+const getInfoItemTemp = `	    m.%sMethodInfo(),`
+
+const getInfoTemp = `
+func (m *Methods) GetMethods() []*jsonrpc.MethodInfo {
+	return []*jsonrpc.MethodInfo{
+%s
+	}
+}`

--- a/misc/regopls/lsp/method_structures.go
+++ b/misc/regopls/lsp/method_structures.go
@@ -1,0 +1,250 @@
+package lsp
+
+import "github.com/open-policy-agent/opa/misc/regopls/lsp/defines"
+
+type method struct {
+	Name          string
+	RegisterName  string
+	Args          interface{}
+	Result        interface{}
+	Error         interface{}
+	Code          interface{}
+	ProgressToken interface{}
+	WithBuiltin   bool
+}
+
+type or []interface{}
+
+var methods = []method{
+	{
+		Name:        "Initialize",
+		Args:        defines.InitializeParams{},
+		Result:      defines.InitializeResult{},
+		Error:       defines.InitializeError{},
+		Code:        defines.InitializeErrorUnknownProtocolVersion,
+		WithBuiltin: true,
+	},
+	{
+		Name: "Initialized",
+		Args: defines.InitializeParams{},
+	},
+	{
+		Name: "Shutdown",
+	},
+	{
+		Name: "Exit",
+	},
+	{
+		Name: "DidChangeConfiguration",
+		Args: defines.DidChangeConfigurationParams{},
+	},
+	{
+		Name: "DidChangeWatchedFiles",
+		Args: defines.DidChangeWatchedFilesParams{},
+	},
+	{
+		Name: "DidOpenTextDocument",
+		Args: defines.DidOpenTextDocumentParams{},
+	},
+	{
+		Name: "DidChangeTextDocument",
+		Args: defines.DidChangeTextDocumentParams{},
+	},
+	{
+		Name: "DidCloseTextDocument",
+		Args: defines.DidCloseTextDocumentParams{},
+	},
+	{
+		Name: "WillSaveTextDocument",
+		Args: defines.WillSaveTextDocumentParams{},
+	},
+	{
+		Name: "DidSaveTextDocument",
+		Args: defines.DidSaveTextDocumentParams{},
+	},
+	{
+		Name:          "ExecuteCommand",
+		Args:          defines.ExecuteCommandParams{},
+		Result:        interface{}(nil),
+		Error:         nil,
+		ProgressToken: nil,
+	},
+	{
+		Name:         "Hover",
+		RegisterName: "textDocument/hover",
+		Args:         defines.HoverParams{},
+		Result:       defines.Hover{},
+	},
+	{
+		Name:          "Completion",
+		RegisterName:  "textDocument/completion",
+		Args:          defines.CompletionParams{},
+		Result:        []defines.CompletionItem{},
+		ProgressToken: []defines.CompletionItem{},
+	},
+	{
+		Name:         "CompletionResolve",
+		RegisterName: "completionItem/resolve",
+		Args:         defines.CompletionItem{},
+		Result:       defines.CompletionItem{},
+	},
+	{
+		Name:         "SignatureHelp",
+		RegisterName: "textDocument/signatureHelp",
+		Args:         defines.SignatureHelpParams{},
+		Result:       defines.SignatureHelp{},
+	},
+	{
+		Name:          "Declaration",
+		RegisterName:  "textDocument/declaration",
+		Args:          defines.DeclarationParams{},
+		Result:        []defines.LocationLink{},
+		ProgressToken: or{[]defines.Location{}, []defines.LocationLink{}},
+	},
+	{
+		Name:          "Definition",
+		RegisterName:  "textDocument/definition",
+		Args:          defines.DefinitionParams{},
+		Result:        []defines.LocationLink{},
+		ProgressToken: or{[]defines.Location{}, []defines.LocationLink{}},
+	},
+	{
+		Name:          "TypeDefinition",
+		RegisterName:  "textDocument/typeDefinition",
+		Args:          defines.TypeDefinitionParams{},
+		Result:        []defines.LocationLink{},
+		ProgressToken: or{[]defines.Location{}, []defines.LocationLink{}},
+	},
+	{
+		Name:          "Implementation",
+		RegisterName:  "textDocument/implementation",
+		Args:          defines.ImplementationParams{},
+		Result:        []defines.LocationLink{},
+		ProgressToken: or{[]defines.Location{}, []defines.LocationLink{}},
+	},
+	{
+		Name:          "References",
+		RegisterName:  "textDocument/references",
+		Args:          defines.ReferenceParams{},
+		Result:        []defines.Location{},
+		ProgressToken: []defines.Location{},
+	},
+	{
+		Name:          "DocumentHighlight",
+		RegisterName:  "textDocument/documentHighlight",
+		Args:          defines.DocumentHighlightParams{},
+		Result:        []defines.DocumentHighlight{},
+		ProgressToken: []defines.DocumentHighlight{},
+	},
+	{
+		Name:          "DocumentSymbol",
+		RegisterName:  "textDocument/documentSymbol",
+		Args:          defines.DocumentSymbolParams{},
+		Result:        or{[]defines.DocumentSymbol{}, []defines.SymbolInformation{}},
+		ProgressToken: or{[]defines.DocumentSymbol{}, []defines.SymbolInformation{}},
+	},
+	{
+		Name:          "WorkspaceSymbol",
+		RegisterName:  "workspace/symbol",
+		Args:          defines.WorkspaceSymbolParams{},
+		Result:        []defines.SymbolInformation{},
+		ProgressToken: []defines.SymbolInformation{},
+	},
+	{
+		Name:          "CodeAction",
+		RegisterName:  "textDocument/codeAction",
+		Args:          defines.CodeActionParams{},
+		Result:        or{[]defines.Command{}, []defines.CodeAction{}},
+		ProgressToken: or{[]defines.Command{}, []defines.CodeAction{}},
+	},
+	{
+		Name:         "CodeActionResolve",
+		RegisterName: "codeAction/resolve",
+		Args:         defines.CodeAction{},
+		Result:       defines.CodeAction{},
+	},
+	{
+		Name:          "CodeLens",
+		RegisterName:  "textDocument/codeLens",
+		Args:          defines.CodeLensParams{},
+		Result:        []defines.CodeLens{},
+		ProgressToken: []defines.CodeLens{},
+	},
+	{
+		Name:         "CodeLensResolve",
+		RegisterName: "codeLens/resolve",
+		Args:         defines.CodeLens{},
+		Result:       defines.CodeLens{},
+	},
+	{
+		Name:         "DocumentFormatting",
+		RegisterName: "textDocument/formatting",
+		Args:         defines.DocumentFormattingParams{},
+		Result:       []defines.TextEdit{},
+	},
+	{
+		Name:         "DocumentRangeFormatting",
+		RegisterName: "textDocument/rangeFormatting",
+		Args:         defines.DocumentRangeFormattingParams{},
+		Result:       []defines.TextEdit{},
+	},
+	{
+		Name:         "DocumentOnTypeFormatting",
+		RegisterName: "textDocument/onTypeFormatting",
+		Args:         defines.DocumentOnTypeFormattingParams{},
+		Result:       []defines.TextEdit{},
+	},
+	{
+		Name:         "RenameRequest",
+		RegisterName: "textDocument/rename",
+		Args:         defines.RenameParams{},
+		Result:       defines.WorkspaceEdit{},
+	},
+	{
+		Name:         "PrepareRename",
+		RegisterName: "textDocument/rename",
+		Args:         defines.PrepareRenameParams{},
+		Result:       defines.Range{},
+	},
+	{
+		Name:          "DocumentLinks",
+		RegisterName:  "textDocument/documentLink",
+		Args:          defines.DocumentLinkParams{},
+		Result:        []defines.DocumentLink{},
+		ProgressToken: []defines.DocumentLink{},
+	},
+	{
+		Name:         "DocumentLinkResolve",
+		RegisterName: "documentLink/resolve",
+		Args:         defines.DocumentLink{},
+		Result:       defines.DocumentLink{},
+	},
+	{
+		Name:          "DocumentColor",
+		RegisterName:  "textDocument/documentColor",
+		Args:          defines.DocumentColorParams{},
+		Result:        []defines.ColorInformation{},
+		ProgressToken: []defines.ColorInformation{},
+	},
+	{
+		Name:          "ColorPresentation",
+		RegisterName:  "textDocument/colorPresentation",
+		Args:          defines.ColorPresentationParams{},
+		Result:        []defines.ColorPresentation{},
+		ProgressToken: []defines.ColorPresentation{},
+	},
+	{
+		Name:          "FoldingRanges",
+		RegisterName:  "textDocument/foldingRange",
+		Args:          defines.FoldingRangeParams{},
+		Result:        []defines.FoldingRange{},
+		ProgressToken: []defines.FoldingRange{},
+	},
+	{
+		Name:          "SelectionRanges",
+		RegisterName:  "textDocument/selectionRange",
+		Args:          defines.SelectionRangeParams{},
+		Result:        []defines.SelectionRange{},
+		ProgressToken: []defines.SelectionRange{},
+	},
+}

--- a/misc/regopls/lsp/option.go
+++ b/misc/regopls/lsp/option.go
@@ -1,0 +1,41 @@
+package lsp
+
+import "github.com/open-policy-agent/opa/misc/regopls/lsp/defines"
+
+type Options struct {
+	// if Network is null, will use stdio
+	Network                          string
+	Address                          string
+	TextDocumentSync                 defines.TextDocumentSyncKind
+	CompletionProvider               *defines.CompletionOptions
+	HoverProvider                    *defines.HoverOptions
+	SignatureHelpProvider            *defines.SignatureHelpOptions
+	DeclarationProvider              *defines.DeclarationOptions
+	DefinitionProvider               *defines.DefinitionOptions
+	TypeDefinitionProvider           *defines.TypeDefinitionOptions
+	ImplementationProvider           *defines.ImplementationOptions
+	ReferencesProvider               *defines.ReferenceOptions
+	DocumentHighlightProvider        *defines.DocumentHighlightOptions
+	DocumentSymbolProvider           *defines.DocumentSymbolOptions
+	CodeActionProvider               *defines.CodeActionOptions
+	CodeLensProvider                 *defines.CodeLensOptions
+	DocumentLinkProvider             *defines.DocumentLinkOptions
+	ColorProvider                    *defines.DocumentColorOptions
+	ColorWithRegistrationProvider    *defines.DocumentColorRegistrationOptions
+	WorkspaceSymbolProvider          *defines.WorkspaceSymbolOptions
+	DocumentFormattingProvider       *defines.DocumentFormattingOptions
+	DocumentRangeFormattingProvider  *defines.DocumentRangeFormattingOptions
+	DocumentOnTypeFormattingProvider *defines.DocumentOnTypeFormattingOptions
+	RenameProvider                   *defines.RenameOptions
+	FoldingRangeProvider             *defines.FoldingRangeOptions
+	SelectionRangeProvider           *defines.SelectionRangeOptions
+	ExecuteCommandProvider           *defines.ExecuteCommandOptions
+	CallHierarchyProvider            *defines.CallHierarchyOptions
+	LinkProvider                     *defines.DocumentLinkOptions
+	SemanticTokensProvider           *defines.SemanticTokensOptions
+	Workspace                        *struct {
+		FileOperations *defines.FileOperationOptions
+	}
+	MonikerProvider *defines.MonikerOptions
+	Experimental    interface{}
+}

--- a/misc/regopls/lsp/run_methods_gen.go
+++ b/misc/regopls/lsp/run_methods_gen.go
@@ -1,0 +1,230 @@
+package lsp
+
+import (
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/misc/regopls/lsp/defines"
+)
+
+type typ_ struct {
+	typName string
+	typ     string
+}
+
+func removeNamePrefix(s string) string {
+	n := strings.Split(s, ".")
+	name := n[len(n)-1]
+	return name
+}
+
+func getTypeOne(i interface{}) typ_ {
+	t := reflect.TypeOf(i)
+	strT := t.String()
+	name := removeNamePrefix(strT)
+	if t.Kind() == reflect.Slice {
+		return typ_{typ: strT, typName: "Slice" + removeNamePrefix(t.Elem().Name())}
+	}
+	return typ_{name, strT}
+}
+
+func getType(i interface{}) []typ_ {
+	res := []typ_{}
+	if isNil(i) {
+		return res
+	}
+	t := reflect.TypeOf(i)
+	if t == reflect.TypeOf(or{}) {
+		orItems := i.(or)
+		for _, item := range orItems {
+			res = append(res, getTypeOne(item))
+		}
+		return res
+	}
+	res = append(res, getTypeOne(i))
+	return res
+}
+
+var test = method{
+	Name:        "Initialize",
+	Args:        defines.InitializeParams{},
+	Result:      or{defines.InitializeResult{}, defines.DocumentLink{}},
+	Error:       defines.InitializeError{},
+	Code:        defines.InitializeErrorUnknownProtocolVersion,
+	WithBuiltin: true,
+}
+
+func firstLow(s string) string {
+	if len(s) < 1 {
+		return s
+	}
+	return strings.ToLower(s[0:1]) + s[1:]
+}
+
+func firstUp(s string) string {
+	if len(s) < 1 {
+		return s
+	}
+	return strings.ToUpper(s[0:1]) + s[1:]
+}
+
+func generateOne(name, regName, args, result, error, code string, withBuiltin bool) (string, string, string) {
+	name = firstUp(name)
+	nameFirstLow := firstLow(name)
+	structField := fmt.Sprintf(structItemTemp, name, args, result, error)
+	method := fmt.Sprintf(methodsTemp, name, args, result, error, name)
+	defaultOpt := noBuiltinTemp
+	if withBuiltin {
+		defaultOpt = fmt.Sprintf(builtinTemp, name, code)
+	}
+	rpcHandler := fmt.Sprintf(jsonrpcHandlerTemp, nameFirstLow, args, name, name, code, defaultOpt)
+	retArgs := "&" + args + "{}"
+	if args == "interface{}" {
+		retArgs = "nil"
+	}
+	defaultRet := ""
+	if !withBuiltin {
+		defaultRet = fmt.Sprintf(methodInfoDefaultTemp, name)
+	}
+	methodsInfo := fmt.Sprintf(methodsInfoTemp, nameFirstLow, defaultRet, regName, retArgs, nameFirstLow)
+	getInfo := fmt.Sprintf(getInfoItemTemp, nameFirstLow)
+	return structField, fmt.Sprintf("%s\n%s\n%s", method, rpcHandler, methodsInfo), getInfo
+}
+
+func generateOneNoResp(name, regName, args, error, code string, withBuiltin bool) (string, string, string) {
+	name = firstUp(name)
+	nameFirstLow := firstLow(name)
+	structField := fmt.Sprintf(noRespStructItemTemp, name, args, error)
+	method := fmt.Sprintf(noRespMethodsTemp, name, args, error, name)
+	defaultOpt := noBuiltinTemp
+	if withBuiltin {
+		defaultOpt = fmt.Sprintf(noRespBuiltinTemp, name, code)
+	}
+	rpcHandler := fmt.Sprintf(noRespJsonrpcHandlerTemp, nameFirstLow, args, name, name, code, defaultOpt)
+	retArgs := "&" + args + "{}"
+	if args == "interface{}" {
+		retArgs = "nil"
+	}
+	defaultRet := ""
+	if !withBuiltin {
+		defaultRet = fmt.Sprintf(methodInfoDefaultTemp, name)
+	}
+	methodsInfo := fmt.Sprintf(methodsInfoTemp, nameFirstLow, defaultRet, regName, retArgs, nameFirstLow)
+	getInfo := fmt.Sprintf(getInfoItemTemp, nameFirstLow)
+	return structField, fmt.Sprintf("%s\n%s\n%s", method, rpcHandler, methodsInfo), getInfo
+}
+
+func TestMethodsGen(t *testing.T) {
+	res := generate(methods)
+	err := ioutil.WriteFile("./generated_methods.go", []byte(res), 0777)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func generate(items []method) string {
+	codeBlock1 := []string{}
+	codeBlock2 := []string{}
+	codeBlock3 := []string{}
+	for _, item := range items {
+		name := item.Name
+		regName := item.RegisterName
+		if regName == "" {
+			regName = firstLow(name)
+		}
+		builtin := item.WithBuiltin
+		args := getType(item.Args)
+		result := getType(item.Result)
+		error := getType(item.Error)
+		code := fmt.Sprintf("%d", item.Code)
+		if isNil(item.Code) {
+			code = "0"
+		}
+		errorT := ""
+		if len(error) == 0 {
+			errorT = "error"
+		} else if len(error) == 1 {
+			errorT = "*" + error[0].typ
+		} else {
+			panic(fmt.Sprintf("not supported %v", item))
+		}
+		if len(args) == 0 {
+			args = append(args, typ_{typ: "interface{}", typName: "nil"})
+		}
+		if len(result) == 0 {
+			if len(args) == 0 {
+				panic(fmt.Sprintf("not supported %v", item))
+			}
+			if len(args) == 1 {
+				a, b, c := generateOneNoResp(name, regName, args[0].typ, errorT, code, builtin)
+				codeBlock1 = append(codeBlock1, a)
+				codeBlock2 = append(codeBlock2, b)
+				codeBlock3 = append(codeBlock3, c)
+			} else {
+				for _, n := range args {
+					newName := name + "With" + n.typName
+					a, b, c := generateOneNoResp(newName, regName, n.typ, errorT, code, builtin)
+					codeBlock1 = append(codeBlock1, a)
+					codeBlock2 = append(codeBlock2, b)
+					codeBlock3 = append(codeBlock3, c)
+				}
+			}
+		}
+
+		if len(result) == 1 {
+			if len(args) == 0 {
+				panic(fmt.Sprintf("not supported %v", item))
+			}
+			if len(args) == 1 {
+				a, b, c := generateOne(name, regName, args[0].typ, result[0].typ, errorT, code, builtin)
+				codeBlock1 = append(codeBlock1, a)
+				codeBlock2 = append(codeBlock2, b)
+				codeBlock3 = append(codeBlock3, c)
+			} else {
+				for _, n := range args {
+					newName := name + "With" + n.typName
+					a, b, c := generateOne(newName, regName, n.typ, result[0].typ, errorT, code, builtin)
+					codeBlock1 = append(codeBlock1, a)
+					codeBlock2 = append(codeBlock2, b)
+					codeBlock3 = append(codeBlock3, c)
+				}
+			}
+		}
+
+		if len(result) > 1 {
+			if len(args) == 0 {
+				panic(fmt.Sprintf("not supported %v", item))
+			}
+			if len(args) == 1 {
+				for _, n := range result {
+					newName := name + "With" + n.typName
+					a, b, c := generateOne(newName, regName, args[0].typ, n.typ, errorT, code, builtin)
+					codeBlock1 = append(codeBlock1, a)
+					codeBlock2 = append(codeBlock2, b)
+					codeBlock3 = append(codeBlock3, c)
+				}
+			} else {
+				for _, r := range result {
+					for _, n := range args {
+						newName := name + "With" + n.typName + "With" + r.typName
+						a, b, c := generateOne(newName, regName, r.typ, n.typ, errorT, code, builtin)
+						codeBlock1 = append(codeBlock1, a)
+						codeBlock2 = append(codeBlock2, b)
+						codeBlock3 = append(codeBlock3, c)
+					}
+				}
+
+			}
+		}
+	}
+	pkg := "// code gen by run_methods_gen.go, do not edit!\npackage lsp\n"
+	code1 := strings.Join(codeBlock1, "\n")
+	code2 := strings.Join(codeBlock2, "\n")
+	code3 := strings.Join(codeBlock3, "\n")
+	code1 = fmt.Sprintf(structTemp, code1)
+	code3 = fmt.Sprintf(getInfoTemp, code3)
+	return pkg + code1 + "\n" + code2 + "\n" + code3
+}

--- a/misc/regopls/lsp/server.go
+++ b/misc/regopls/lsp/server.go
@@ -1,0 +1,84 @@
+package lsp
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+
+	"github.com/open-policy-agent/opa/misc/regopls/jsonrpc"
+	"github.com/open-policy-agent/opa/misc/regopls/logs"
+)
+
+type Server struct {
+	Methods
+	rpcServer *jsonrpc.Server
+}
+
+func NewServer(opt *Options) *Server {
+	s := &Server{}
+	s.Opt = *opt
+	s.rpcServer = jsonrpc.NewServer()
+	return s
+}
+
+func (s *Server) Run() {
+	mtds := s.GetMethods()
+	for _, m := range mtds {
+		if m != nil {
+			s.rpcServer.RegisterMethod(*m)
+		}
+	}
+
+	s.run()
+}
+
+func (s *Server) run() {
+	addr := s.Opt.Address
+	netType := s.Opt.Network
+	if netType != "" {
+		if addr == "" {
+			addr = "127.0.0.1:7998"
+		}
+		logs.Printf("use socket mode: net: %s, addr: %s\n", netType, addr)
+		listener, err := net.Listen(netType, addr)
+		if err != nil {
+			panic(err)
+		}
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				panic(err)
+			}
+			go s.rpcServer.ConnComeIn(conn)
+		}
+	} else {
+		logs.Println("use stdio mode.")
+		// use stdio mode
+		s.rpcServer.ConnComeIn(NewStdio())
+	}
+}
+
+func wrapErrorToRespError(err interface{}, code int) error {
+	if isNil(err) {
+		return nil
+	}
+	if e, ok := err.(error); ok {
+		return e
+	}
+	return jsonrpc.ResponseError{
+		Code:    code,
+		Message: fmt.Sprintf("%v", err),
+		Data:    err,
+	}
+}
+
+func isNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	v := reflect.ValueOf(i)
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return true
+	}
+	return false
+}

--- a/misc/regopls/lsp/stdio.go
+++ b/misc/regopls/lsp/stdio.go
@@ -1,0 +1,41 @@
+package lsp
+
+import (
+	"io"
+	"os"
+
+	"github.com/open-policy-agent/opa/misc/regopls/jsonrpc"
+)
+
+type stdioReaderWriter struct {
+	reader   io.Reader
+	writer   io.Writer
+	isClosed bool
+}
+
+func NewStdio() jsonrpc.ReaderWriter {
+	return &stdioReaderWriter{
+		reader:   os.Stdin,
+		writer:   os.Stdout,
+		isClosed: false,
+	}
+}
+
+func (s *stdioReaderWriter) Read(p []byte) (n int, err error) {
+	if s.isClosed {
+		return 0, io.EOF
+	}
+	return s.reader.Read(p)
+}
+
+func (s *stdioReaderWriter) Write(p []byte) (n int, err error) {
+	if s.isClosed {
+		return 0, io.EOF
+	}
+	return s.writer.Write(p)
+}
+
+func (s *stdioReaderWriter) Close() error {
+	s.isClosed = true
+	return nil
+}


### PR DESCRIPTION
Add skeleton language server from https://github.com/TobiasYin/go-lsp

- Custom jsonrpc library in jsonrpc
- Custom logs setup in logs
- Language server skeleton and method signatures in lsp
  - Code to generate generated_methods.go are: run_methods_gen.go, method_structures.go, method_placeholders.go (entrypoint is defined as a test `TestMethodsGen`)
- Protocol definition for [LSP](https://microsoft.github.io/language-server-protocol/) in lsp/defines
- Example server defined in regopls/cmd.go